### PR TITLE
Move log in to after onboarding

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -79,7 +79,7 @@ end
            User.create_with_omniauth(auth)
     session[:user_id] = user.id
     flash[:notice] = 'Signed in!'
-    redirect to('/')
+    redirect to('/countries')
   end
 end
 

--- a/app.rb
+++ b/app.rb
@@ -93,7 +93,7 @@ end
 before '/countries*' do
   pass if current_user
   flash[:alert] = 'Please sign in'
-  redirect to('/')
+  redirect to('/login')
 end
 
 get '/countries' do

--- a/views/about.erb
+++ b/views/about.erb
@@ -39,5 +39,5 @@
 </div>
 
 <p style="text-align: center">
-    <a class="button button--primary" href="/login">Play the game</a>
+    <a class="button button--primary" href="/">Home</a>
 </p>

--- a/views/index.erb
+++ b/views/index.erb
@@ -13,11 +13,7 @@
     <% end %>
     <p>Let’s sort the women from the boys.</p>
     <ul class="home-loggedin">
-      <% if current_user.responses.any? %>
-        <li><a class="button button--primary" href="/countries">Continue game</a></li>
-      <% else %>
-        <li><a class="button button--primary" href="/onboarding">Here’s how</a></li>
-      <% end %>
+        <li><a class="button button--primary" href="/countries">Play</a></li>
         <li>
             <a style="margin-right: 0.5em" href="<%= url '/about' %>">About</a> &middot;
             <a style="margin-left: 0.5em"  href="<%= url '/logout' %>">Log out</a>

--- a/views/index.erb
+++ b/views/index.erb
@@ -31,7 +31,7 @@
 <% unless current_user %>
   <div class="home-secondary">
     <ul class="home-cta">
-        <li><a href="/countries">Play</a></li><!--
+        <li><a href="/onboarding">Play</a></li><!--
         --><li><a href="/about">About</a></li>
     </ul>
     <div class="home-persuasion">

--- a/views/index.erb
+++ b/views/index.erb
@@ -28,7 +28,7 @@
 <% unless current_user %>
   <div class="home-secondary">
     <ul class="home-cta">
-        <li><a href="/login">Play</a></li><!--
+        <li><a href="/countries">Play</a></li><!--
         --><li><a href="/about">About</a></li>
     </ul>
     <div class="home-persuasion">


### PR DESCRIPTION
Change the flow so that new users can (/must) go through onboarding _before_ logging in, rather than making them log in first.

This still isn't great, as if they log out, then they'll need to go back through onboarding when they return, but this improves the default flow considerably, so I think it's worth merging now, and then solving the wider issue once we store progress properly (including whether or not onboarding is complete) — especially as the existing flow would also make the person go through onboarding again unless they'd submitted at least one response. 

Fixes #91. Fixes #104 