### PR TITLE
Fix #100 - stop blocking touchstart/end on the jtinder element

### DIFF
--- a/public/js/jquery.jtinder.js
+++ b/public/js/jquery.jtinder.js
@@ -49,9 +49,9 @@
       pane_width = container.width();
       $that = this;
 
-      $(element).bind('touchstart mousedown', this.handler);
-      $(element).bind('touchmove mousemove', this.handler);
-      $(element).bind('touchend mouseup', this.handler);
+      container.bind('touchstart mousedown', this.handler);
+      container.bind('touchmove mousemove', this.handler);
+      container.bind('touchend mouseup', this.handler);
     },
 
     getPanes: function(){


### PR DESCRIPTION
Fixes #100.

The button at the end of onboarding is now clickable on touchscreens.