### PR TITLE
Keyboard shortcuts for voting buttons

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -116,6 +116,22 @@ $(function(){
       loadNewPerson();
       $('.js-jtinder').jTinder('skip');
     });
+
+    $(document).on('keydown', function(e){
+      if(e.keyCode == 77 || e.keyCode == 37){
+        // m key or left arrow
+        $('.js-jtinder-dislike').trigger('click');
+      } else if(e.keyCode == 70 || e.keyCode == 39){
+        // f key or right arrow
+        $('.js-jtinder-like').trigger('click');
+      } else if(e.keyCode == 32 || e.keyCode == 38){
+        // space key or up arrow
+        $('.js-person-skip').trigger('click');
+      } else if(e.keyCode == 79 || e.keyCode == 40){
+        // o key or down arrow
+        $('.js-person-other').trigger('click');
+      }
+    });
   }
 
   $('[data-filter-elements]').on('keyup', function(){


### PR DESCRIPTION
Did this quickly on the train, but it should work as expected.

Note: we don't tell people what the keyboard shortcuts *are* – maybe it should be in the onboarding? Or maybe in a little "popup" card in the stack? ("Did you know, you can use your keyboard [image of keys]")

Obviously, this is only useful on devices with hardware keyboards.