### PR TITLE
Use the responses.legislative_period_id for lookup

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,7 @@ class User < Sequel::Model
 
   def last_response_for(country, legislature)
     responses_dataset.join(:legislative_periods, id: :legislative_period_id)
+      .select(Sequel.qualify(:responses, :legislative_period_id))
       .where(country_code: country[:code], legislature_slug: legislature[:slug])
       .order(:start_date)
       .first
@@ -41,7 +42,7 @@ class User < Sequel::Model
     legislative_periods = legislative_periods_for(country, legislature)
     last_response = last_response_for(country, legislature)
     return legislative_periods.first unless last_response
-    last_legislative_period = LegislativePeriod.first(legislative_period_id: last_response.legislative_period_id)
+    last_legislative_period = LegislativePeriod[last_response.legislative_period_id]
     if incomplete?(last_legislative_period)
       last_legislative_period
     else


### PR DESCRIPTION
Previously it was incorrectly using the legislative_period_id from the
legislative_periods table, which is the EveryPolitician legislative
period, but actually we wanted it to be using the legislative_periods.id
field which in the responses table is called legislative_period_id.

This switches to selecting just the
'responses.legislative_period_id' field and then using that to lookup
the LegislativePeriod model by its primary key.

Fixes #127 