### PR TITLE
Only show people once per term

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,14 +45,6 @@ namespace :cache do
     end
   end
 
-
-  def csv_for(ref, path)
-    csv_url = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/' \
-      "#{ref}/#{path}"
-    puts csv_url
-    CSV.parse(open(csv_url).read, headers: true, header_converters: :symbol)
-  end
-
   task legislative_periods: :app do
     countries_json = 'https://github.com/everypolitician/' \
       'everypolitician-data/raw/master/countries.json'
@@ -70,8 +62,7 @@ namespace :cache do
           next if start_date.nil?
           start_date = "#{start_date}-01-01" if start_date.length == 4
           lp.start_date = Date.parse(start_date)
-          csv = csv_for(legislature[:sha], legislative_period[:csv])
-          lp.person_count = csv.length
+          lp.person_count = lp.unique_people.size
           lp.save
         end
       end

--- a/app/models/legislative_period.rb
+++ b/app/models/legislative_period.rb
@@ -41,7 +41,11 @@ class LegislativePeriod < Sequel::Model
     end
   end
 
+  def unique_people
+    csv.uniq { |person| person[:id] }
+  end
+
   def already_have_gender
-    csv.count { |person| person[:gender] }
+    unique_people.count { |person| person[:gender] }
   end
 end

--- a/app/models/legislative_period.rb
+++ b/app/models/legislative_period.rb
@@ -42,7 +42,7 @@ class LegislativePeriod < Sequel::Model
   end
 
   def unique_people
-    csv.uniq { |person| person[:id] }
+    csv.map(&:to_h).to_a.uniq { |person| person[:id] }
   end
 
   def already_have_gender

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,15 +52,6 @@ class User < Sequel::Model
   end
 
   def incomplete?(legislative_period)
-    total = legislative_period.person_count
-    completed = responses_dataset
-      .join(:legislative_periods, id: :legislative_period_id)
-      .where(
-        country_code: legislative_period.country[:code],
-        legislature_slug: legislative_period.legislature[:slug],
-        politician_id: legislative_period.unique_people.map { |row| row[:id] }
-      ).count
-    already_have_gender = legislative_period.already_have_gender
-    (completed + already_have_gender) != total
+    people_for(legislative_period).any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < Sequel::Model
   end
 
   def people_for(legislative_period)
-    people = legislative_period.csv
+    people = legislative_period.unique_people
     already_done = responses_dataset
       .join(:legislative_periods, id: :legislative_period_id)
       .where(
@@ -23,7 +23,7 @@ class User < Sequel::Model
       .map(:politician_id)
     people = people.reject { |person| already_done.include?(person[:id]) }
     people = people.reject { |person| person[:gender] }
-    people.shuffle
+    people.uniq { |p| p[:id] }.shuffle
   end
 
   def legislative_periods_for(country, legislature)
@@ -58,7 +58,7 @@ class User < Sequel::Model
       .where(
         country_code: legislative_period.country[:code],
         legislature_slug: legislative_period.legislature[:slug],
-        politician_id: legislative_period.csv.map { |row| row[:id] }
+        politician_id: legislative_period.unique_people.map { |row| row[:id] }
       ).count
     already_have_gender = legislative_period.already_have_gender
     (completed + already_have_gender) != total

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -35,9 +35,9 @@ module Helpers
   end
 
   def percent_complete_term(legislative_period)
-    total_people = legislative_period.csv.size
+    total_people = legislative_period.csv.uniq { |p| p[:id] }.size
     response_count = current_user.responses_dataset.where(
-      politician_id: legislative_period.csv.map { |row| row[:id] },
+      politician_id: legislative_period.csv.map { |row| row[:id] }.uniq,
       legislative_period_id: legislative_period.id
     ).count
     complete_people = response_count

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -35,9 +35,9 @@ module Helpers
   end
 
   def percent_complete_term(legislative_period)
-    total_people = legislative_period.csv.uniq { |p| p[:id] }.size
+    total_people = legislative_period.unique_people.size
     response_count = current_user.responses_dataset.where(
-      politician_id: legislative_period.csv.map { |row| row[:id] }.uniq,
+      politician_id: legislative_period.unique_people.map { |row| row[:id] },
       legislative_period_id: legislative_period.id
     ).count
     complete_people = response_count

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -4,14 +4,6 @@ module Helpers
     @current_user ||= User[session[:user_id]]
   end
 
-  def csv_for(ref, path, last_modified)
-    settings.cache_client.fetch([ref, path, last_modified].join(':'), 1.month) do
-      csv_url = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/' \
-        "#{ref}/#{path}"
-      CSV.parse(open(csv_url).read, headers: true, header_converters: :symbol)
-    end
-  end
-
   def country_counts
     @country_counts ||= CountryCount.to_hash(:country_code, :person_count)
   end


### PR DESCRIPTION
This adds a method to the `LegislativePeriod` which returns unique people per-term. It also ensures that the calculation used to figure out if a term is incomplete is the same as the one that returns people for a term.

After this has been deployed `rake cache:legislative_periods` needs to be run to update the term counts.

Fixes #117 