### PR TITLE
Swap vertical order of "Other" and "Don’t know" buttons

### DIFF
--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -102,8 +102,8 @@
 </ul>
 
 <div class="controls">
-    <a class="controls__skip js-person-skip" href="#">Don’t know</a>
-    <a class="controls__male js-jtinder-dislike" href="#">Male</a>
-    <a class="controls__female js-jtinder-like" href="#">Female</a>
-    <a class="controls__other js-person-other" href="#">Other</a>
+    <div class="controls__skip js-person-skip" href="#">Don’t know</div>
+    <div class="controls__male js-jtinder-dislike" href="#">Male</div>
+    <div class="controls__female js-jtinder-like" href="#">Female</div>
+    <div class="controls__other js-person-other" href="#">Other</div>
 </div>

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -102,8 +102,8 @@
 </ul>
 
 <div class="controls">
-    <a class="controls__other js-person-other" href="#">Other</a>
+    <a class="controls__skip js-person-skip" href="#">Don’t know</a>
     <a class="controls__male js-jtinder-dislike" href="#">Male</a>
     <a class="controls__female js-jtinder-like" href="#">Female</a>
-    <a class="controls__skip js-person-skip" href="#">Don’t know</a>
+    <a class="controls__other js-person-other" href="#">Other</a>
 </div>

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -326,7 +326,7 @@ body.person-page {
     font-size: 0.8em;
     background-color: $color_grey;
 
-    bottom: 5.5em;
+    bottom: 0.5em;
     margin-left: -2em;
 
     &:hover,
@@ -340,7 +340,7 @@ body.person-page {
 }
 
 .controls__skip {
-    bottom: 0.5em;
+    bottom: 5.5em;
     line-height: 1.2em;
     padding: 0.8em 0;
 }

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -254,6 +254,13 @@ body.person-page {
     z-index: 10;
     text-align: center;
 
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
     @media (min-height: 500px) {
         bottom: 1em;
     }
@@ -274,17 +281,11 @@ body.person-page {
     text-decoration: none;
     position: absolute;
     left: 50%;
-
-    // Avoid square grey outlines on touch
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
+    cursor: pointer;
 
     &:hover,
     &:focus {
         color: $color_white;
-    }
-
-    &:focus {
-        outline: none;
     }
 }
 

--- a/views/term.erb
+++ b/views/term.erb
@@ -57,10 +57,10 @@
 </ul>
 
 <div class="controls js-controls">
-    <a class="controls__other js-person-other" href="#">Other</a>
+    <a class="controls__skip js-person-skip" href="#">Don’t<br>know</a>
     <a class="controls__male js-jtinder-dislike" href="#">Male</a>
     <a class="controls__female js-jtinder-like" href="#">Female</a>
-    <a class="controls__skip js-person-skip" href="#">Don’t<br>know</a>
+    <a class="controls__other js-person-other" href="#">Other</a>
     <span class="controls__google">Not sure? <a class="js-google-link" href="#" target="_blank"><i class="fa fa-search"></i>Google them!</a></span>
 </div>
 

--- a/views/term.erb
+++ b/views/term.erb
@@ -57,10 +57,10 @@
 </ul>
 
 <div class="controls js-controls">
-    <a class="controls__skip js-person-skip" href="#">Don’t<br>know</a>
-    <a class="controls__male js-jtinder-dislike" href="#">Male</a>
-    <a class="controls__female js-jtinder-like" href="#">Female</a>
-    <a class="controls__other js-person-other" href="#">Other</a>
+    <div class="controls__skip js-person-skip" href="#">Don’t<br>know</div>
+    <div class="controls__male js-jtinder-dislike" href="#">Male</div>
+    <div class="controls__female js-jtinder-like" href="#">Female</div>
+    <div class="controls__other js-person-other" href="#">Other</div>
     <span class="controls__google">Not sure? <a class="js-google-link" href="#" target="_blank"><i class="fa fa-search"></i>Google them!</a></span>
 </div>
 


### PR DESCRIPTION
It’s likely we’re going to allow "swipe up for Don’t Know" gesture soon (#105). This prepares the way by putting "Don’t Know" on top, so people don’t get a shock later on.

![screen shot 2015-07-24 at 09 34 04](https://cloud.githubusercontent.com/assets/739624/8870583/10e1bd32-31e7-11e5-96a9-b5e06fb2c6b6.png)

Also attempts to remedy #116 by using inert `div`s for the buttons, rather than `a` elements which might be stealing focus and causing click issues.