### PR TITLE
Add a "country missing?" link

### DIFF
--- a/views/about.erb
+++ b/views/about.erb
@@ -22,20 +22,20 @@
     <p>We hope that they will be useful for researchers, campaigners, politicians, sociologists… and you!</p>
 </div>
 
+<div class="static-text-section"><a name="missing"></a>
+    <h2 class="page-title">Why isn’t every parliament on Gender Balance?</h2>
+
+    <p>Gender Balance takes its data from EveryPolitician, where we’ve included the politicians for every legislature we can find information on. If you know where to find data that we haven’t yet included, please do feel <a href="http://everypolitician.org/contribute.html">free to add it</a>.</p>
+</div>
+
 <div class="static-text-section">
     <h2 class="page-title">Who built this?</h2>
 
     <p>Gender Balance was created by developers at <a href="https://mysociety.org">mySociety</a>, using underlying data from <a href="http://everypolitician.org/">EveryPolitician</a>, a database which aims to collect information on every politician in the world.</p>
 
-    <p>Gender Balance exists to nail down gender balance data across every country.</p>
+    <p>Gender Balance exists to discover the gender balance data across every country.</p>
 
     <p>But Gender Balance also aims to be a showcase of what can be done with the open data from EveryPolitician. That data is free for anyone who wants to build tools like this, and it’s easy to use, too. <a href="http://everypolitician.org/about.html">Find out more about that here</a>.</p>
-</div>
-
-<div class="static-text-section">
-    <h2 class="page-title">Why isn’t every parliament on Gender Balance?</h2>
-
-    <p>Gender Balance takes its data from EveryPolitician, where we’ve included the politicians for every legislature we can find information on. If you know where to find data that we haven’t yet included, please do feel <a href="http://everypolitician.org/contribute.html">free to add it</a>.</p>
 </div>
 
 <p style="text-align: center">

--- a/views/countries.erb
+++ b/views/countries.erb
@@ -32,3 +32,5 @@
       <% end %>
     </div>
   <% end %>
+
+  <p class="help-missing">Your country missing? <a href="/about#missing">Find out why.</a></p>


### PR DESCRIPTION
On the list of all countries, add a link to the About page explanation
for why a country might be missing.

![screen shot 2015-07-24 at 13 16 45](https://cloud.githubusercontent.com/assets/57483/8874185/5c6e4206-3206-11e5-9f53-526692366a3e.png)


Closes #157