### PR TITLE
Don't display the term name at the top of the screen

### DIFF
--- a/views/term.erb
+++ b/views/term.erb
@@ -6,8 +6,6 @@
 
 <% if @people.any? %>
 
-    <h3><%= @legislative_period.name %></h3>
-
 <div class="progress-bar progress-bar--healthy" data-total="<%= @legislative_period.unique_people.size %>"><div style="width: <%= percent_complete_term(@legislative_period) %>%"></div></div>
 
 <div class="tindr-cards js-jtinder">


### PR DESCRIPTION
It takes up too much space, and isn’t particularly useful. (It will
still appear at the end of the level.)

Closes #141