### PR TITLE
Improve "Level complete" typography

### DIFF
--- a/config/motivational_quotes.yml
+++ b/config/motivational_quotes.yml
@@ -1,28 +1,23 @@
 ---
-- Great stuff! You’re really helping pin down those numbers.
-- You’re sorting up a storm! Thanks for your help.
-- Go you! Thanks for helping us nail this data down.
-- Yay you! Great job on the sorting.
-- Excellent work, thank you!
-- Great stuff. Journalists, analysts and researchers of the world salute you!
-- You’re the tops at gender sorting! Stick that on your CV, you’re welcome.
-- Keep it up! The researchers of the world will love you forever.
-- Sterling work!
-- High five! You’re doing great.
-- Woah! Who knew you’d be so fab at this whole sorting thing?
-- Keep on keeping on - this is really valuable data, thanks!
-- You’re sorting like billy-o and we love it!
-- w00t, check you out!
+- Great stuff!
+- Great job!
+- Go you!
 - Keep on sorting!
-- You’re super awesome-sauce, yo
-- You da bomb pops
-- Man, you’re really stacking up those figures!
-- Hippity hoppity, don’t you stoppity
-- Good show, yo.
-- Wowsers, you’re good at this.
+- You’re doing great work!
+- Excellent work, thank you!
+- Awesome work, thank you!
+- Sterling work. Keep it up!
 - Have a biscuit, you deserve it.
-- You’re doing great work helping us gather this data.
-- Who made you so good at this?
-- You’re bringing about a change
-- You’re adding to the sum of the world’s knowledge
-- Srsly good stuff
+- High five! You’re doing great.
+- You’re sorting up a storm!
+- You’re the tops at gender sorting!
+- Keep it up. Make a difference!
+- Thanks! Your data makes a difference.
+- Researchers will love that data!
+- Journalists will love that data!
+- One more? It’s for a good cause!
+- And another? It’s for a good cause!
+- w00t, check you out!
+- Hippity hoppity, don’t you stoppity!
+- Wowsers, you’re good at this.
+- Srsly good stuff, yo.

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -24,7 +24,7 @@
     <div class="level-complete">
         <h2>Well done!</h2>
         <p>You’re ready to start playing for real, with a country you know&nbsp;well.</p>
-        <p><a class="button button--primary" href="<%= url '/countries' %>">Pick a country</a></p>
+        <p><a class="button button--primary" href="<%= url '/countries' %>">Play for real!</a></p>
     </div>
 </div>
 

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -204,13 +204,6 @@ body.person-page {
     height: 11em;
     padding: 1em;
 
-    // Vertically centre the card contents (in modern browsers)
-    @include flexbox();
-    @include flex-align(center);
-    @include flex-justify(center);
-    -webkit-box-orient: vertical;
-    @include vendor-prefix(flex-direction, column);
-
     & > * {
         margin: 0;
     }

--- a/views/term.erb
+++ b/views/term.erb
@@ -16,35 +16,36 @@
     </ul>
     <div class="level-complete">
         <h2><%= motivational_quote %></h2>
-        <% if @legislative_period.previous_legislative_period %>
-            <% previous_count = @legislative_period.previous_legislative_periods.count %>
-            <p>
-                You have completed <b><%= @legislative_period.legislature[:name] %> <%= @legislative_period.name %></b>.
-                There <%= previous_count == 1 ? 'is' : 'are' %>
-                <%= previous_count %> more level<%= previous_count == 1 ? '' : 's' %> to play.
-            </p>
-            <p>
-                <a class="button button--secondary" href="<%= url "/countries/#{@legislative_period.country[:slug]}/legislatures/#{@legislative_period.legislature[:slug]}" %>">
-                    Proceed to <%= @legislative_period.previous_legislative_period.name %>
-                </a>
-            </p>
-        <% else %>
-            <% if @legislative_period.country[:legislatures].size == 1 %>
-                <p>You have completed <%= @legislative_period.country[:name] %>.</p>
-                <p>
-                    <a class="button button--secondary" href="<%= url "/countries" %>">
-                        Choose another country
-                    </a>
-                </p>
-            <% else %>
-                <p>You have completed <%= @legislative_period.country[:name] %> <%= @legislative_period.legislature[:name] %>.</p>
-                <p>
-                    <a class="button button--secondary" href="<%= url "/countries/#{@legislative_period.country[:slug]}" %>">
-                        Choose another legislature
-                    </a>
-                </p>
-            <% end %>
-        <% end %>
+
+      <% if @legislative_period.previous_legislative_period %>
+        <% previous_count = @legislative_period.previous_legislative_periods.count %>
+        <p>
+            You have completed <b><%= @legislative_period.legislature[:name] %> <%= @legislative_period.name %></b>.
+            There <%= previous_count == 1 ? 'is' : 'are' %>
+            <%= previous_count %> more level<%= previous_count == 1 ? '' : 's' %> to play.
+        </p>
+        <p>
+            <a class="button button--secondary" href="<%= url "/countries/#{@legislative_period.country[:slug]}/legislatures/#{@legislative_period.legislature[:slug]}" %>">
+                Play the next level!
+            </a>
+        </p>
+
+      <% elsif @legislative_period.country[:legislatures].size == 1 %>
+        <p>You have completed <%= @legislative_period.country[:name] %>.</p>
+        <p>
+            <a class="button button--secondary" href="<%= url "/countries" %>">
+                Choose another country
+            </a>
+        </p>
+
+      <% else %>
+        <p>You have completed <%= @legislative_period.country[:name] %> <%= @legislative_period.legislature[:name] %>.</p>
+        <p>
+            <a class="button button--secondary" href="<%= url "/countries/#{@legislative_period.country[:slug]}" %>">
+                Choose another legislature
+            </a>
+        </p>
+      <% end %>
     </div>
 </div>
 
@@ -63,6 +64,6 @@
 </div>
 
 <% else %>
-  <h2>Nothing to do!</h2> 
+  <h2>Nothing to do!</h2>
   <p><%= @legislative_period.country[:name] %> already publishes gender information for its legislators — but why not <a href="/countries">pick another country</a>?</p>
 <% end %>


### PR DESCRIPTION
I've shortened the randomly-chosen messages so they're mostly 2 lines long, rather than 3–4. Also removed the vertical centring that was causing very long messages to crash into the progress bar above.

Fixes #146.

![screen shot 2015-07-27 at 11 47 02](https://cloud.githubusercontent.com/assets/739624/8904198/41388efa-3455-11e5-965e-b7bd5682bce6.png)