### PR TITLE
Stop very long politician names overlapping edge of cards

### DIFF
--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -148,6 +148,8 @@ body.person-page {
 
 .person__name {
     font-size: 1.5em;
+    width: 100%;
+    word-wrap: break-word;
 
     @media (min-height: 600px), (min-width: $screen_medium_min) {
         font-size: 1.8em;


### PR DESCRIPTION
Fixes #132.

Long names will break onto two lines, like so:

![screen shot 2015-07-27 at 12 04 35](https://cloud.githubusercontent.com/assets/739624/8904472/93c7bba8-3457-11e5-942d-fc104a87f7cd.png)

The name will be hyphenated in browsers that support it (annoyingly not Chrome).