### PR TITLE
Hide level completion message until level is completed

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -26,7 +26,8 @@ var updateProgressBar = function updateProgressBar(){
     width: percent + '%'
   });
   if (percent === 100) {
-    $('.js-controls').hide();
+    $('.js-controls').fadeOut(100);
+    $('.level-complete').fadeIn(100);
   }
 }
 

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -210,6 +210,8 @@ body.person-page {
     height: 11em;
     padding: 1em;
 
+    display: none; // Will be shown by javascript when level is complete.
+
     & > * {
         margin: 0;
     }


### PR DESCRIPTION
Fixes #158 by hiding the "level complete" message until the level is actually complete.

**Note:** This branch relies on the changes made in the [`issues/105-swipe-up`](https://github.com/everypolitician/gender-balance/tree/issues/105-swipe-up) branch (pull request #171). This PR is set to merge into that branch, but you could just as easily merge into `master` once `issues/105-swipe-up` has been accepted.