### PR TITLE
Improved desktop styling

### DIFF
--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -277,7 +277,7 @@ body.person-page {
 
 .controls {
     position: absolute;
-    bottom: 0;
+    bottom: 0.5em;
     left: 0;
     right: 0;
     z-index: 10;
@@ -324,13 +324,15 @@ body.person-page {
 
 .controls__male,
 .controls__female {
-    width: 6em;
-    line-height: 6em;
-    border-radius: 6em;
+    font-size: 0.9em;
+
+    width: 5.5em;
+    line-height: 5.5em;
+    border-radius: 5.5em;
     background-color: $color_orange;
 
     bottom: 1em;
-    margin-left: -8em;
+    margin-left: -8.5em;
 
     &:hover,
     &:focus {
@@ -344,7 +346,7 @@ body.person-page {
 
 .controls__female {
     background-color: $color_green;
-    margin-left: 2em;
+    margin-left: 3em;
 
     &:hover,
     &:focus {
@@ -352,16 +354,17 @@ body.person-page {
     }
 }
 
-.controls__other,
 .controls__skip {
-    width: 4em;
-    line-height: 4em;
-    border-radius: 4em;
-    font-size: 0.8em;
+    font-size: 0.9em;
+
+    width: 5em;
+    line-height: 1.2em;
+    border-radius: 5em;
+    padding: 1.3em 0;
     background-color: $color_grey;
 
-    bottom: 0.5em;
-    margin-left: -2em;
+    bottom: 3.2em;
+    margin-left: -2.5em;
 
     &:hover,
     &:focus {
@@ -369,14 +372,29 @@ body.person-page {
     }
 
     &:active {
-        margin-bottom: -0.3em;
+        margin-bottom: -0.2em;
     }
 }
 
-.controls__skip {
-    bottom: 5.5em;
-    line-height: 1.2em;
-    padding: 0.8em 0;
+.controls__other {
+    font-size: 0.7em;
+
+    width: 5em;
+    line-height: 3em;
+    border-radius: 3em;
+    background-color: mix($color_grey, $color_off_white, 80%);
+
+    bottom: 0;
+    margin-left: -2.5em;
+
+    &:hover,
+    &:focus {
+        background-color: darken(mix($color_grey, $color_off_white, 80%), 5%);
+    }
+
+    &:active {
+        margin-bottom: -0.3em;
+    }
 }
 
 .controls__google {

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -16,15 +16,27 @@ body.person-page {
 
 .person-cards {
     position: relative;
-    height: 16em;
+    height: 10em;
     text-align: center;
-
-    @media (min-width: $screen_medium_min) {
-        padding-top: 1em;
-    }
 
     & > ul {
         @extend .unstyled-list;
+    }
+
+    @media (min-height: 460px) {
+        height: 11em;
+    }
+
+    @media (min-height: 500px) {
+        height: 12em;
+    }
+
+    @media (min-height: 540px) {
+        height: 14em;
+    }
+
+    @media (min-height: 600px) {
+        height: 15em;
     }
 }
 
@@ -39,7 +51,8 @@ body.person-page {
     left: 50%;
     width: 16em;
     margin-left: -8em;
-    height: 11em;
+    height: 10em;
+    line-height: 1.2em;
 
     // Vertically centre the card contents (in modern browsers)
     @include flexbox();
@@ -54,6 +67,22 @@ body.person-page {
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+
+    @media (min-height: 460px) {
+        height: 11em;
+    }
+
+    @media (min-height: 500px) {
+        height: 12em;
+    }
+
+    @media (min-height: 540px) {
+        height: 14em;
+    }
+
+    @media (min-height: 600px) {
+        height: 15em;
+    }
 
     &:first-child {
         cursor: move;
@@ -130,14 +159,22 @@ body.person-page {
 
 .person__picture {
     border-radius: 100%;
-    max-height: 4em;
+    max-height: 3em;
     width: auto;
+
+    @media (min-height: 460px) {
+        max-height: 3.5em;
+    }
+
+    @media (min-height: 500px) {
+        max-height: 4em;
+    }
 
     @media (min-height: 540px) {
         max-height: 4.5em;
     }
 
-    @media (min-height: 600px), (min-width: $screen_medium_min) {
+    @media (min-height: 600px) {
         max-height: 5em;
     }
 
@@ -151,7 +188,7 @@ body.person-page {
     width: 100%;
     word-wrap: break-word;
 
-    @media (min-height: 600px), (min-width: $screen_medium_min) {
+    @media (min-height: 600px) {
         font-size: 1.8em;
     }
 }
@@ -161,7 +198,7 @@ body.person-page {
     margin-top: 0.2em;
     font-size: 0.9em;
 
-    @media (min-height: 600px), (min-width: $screen_medium_min) {
+    @media (min-height: 600px) {
         font-size: 1em;
     }
 }
@@ -189,9 +226,23 @@ body.person-page {
 
 .person-card--advice,
 .level-complete {
-    h2 + p,
-    p + p {
+
+    h2, p {
         margin-top: 0.5em;
+    }
+
+    & > :first-child {
+        margin-top: 0;
+    }
+
+    @media (max-height: 459px) {
+        h2 {
+            font-size: 1.3em;
+        }
+
+        p {
+            font-size: 0.9em;
+        }
     }
 }
 
@@ -207,8 +258,8 @@ body.person-page {
     left: 50%;
     width: 16em;
     margin-left: -8em;
-    height: 11em;
     padding: 1em;
+    line-height: 1.2em;
 
     & > * {
         margin: 0;
@@ -221,27 +272,6 @@ body.person-page {
     @media (min-width: $screen_small_min) {
         width: 16em;
         margin-left: -8em;
-    }
-}
-
-@media (min-height: 500px) {
-    .person-card,
-    .level-complete {
-        height: 12em;
-    }
-}
-
-@media (min-height: 540px) {
-    .person-card,
-    .level-complete {
-        height: 14em;
-    }
-}
-
-@media (min-height: 600px) {
-    .person-card,
-    .level-complete {
-        height: 15em;
     }
 }
 
@@ -268,6 +298,10 @@ body.person-page {
         position: relative;
         height: 12em;
         bottom: 0;
+
+        .onboarding-page & {
+            height: 10em; // Onboarding has no Google link, so can be shorter
+        }
     }
 }
 

--- a/views/sass/main.scss
+++ b/views/sass/main.scss
@@ -32,7 +32,7 @@ body {
 
 @media (min-width: $screen_medium_min) {
     body {
-        padding-top: 2em;
+        padding-top: 1em;
     }
 
     .app {
@@ -43,6 +43,12 @@ body {
     .home-primary, .home-secondary {
         max-width: 700px;
         margin: 0 auto;
+    }
+
+    @media (min-height: 640px){
+        body {
+            padding-top: 2em;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #122 by making the "desktop" view responsive to wide but short windows, so a scrollbar shouldn't be required for normal usage. Here's an example of the onboarding page on a 480px high desktop window:

![screen shot 2015-07-27 at 16 00 06](https://cloud.githubusercontent.com/assets/739624/8909294/8496204a-3478-11e5-95d0-35625ce59e9e.png)

(Previously, the buttons weren't visible at all!)

Since I was editing the button layout already, I figured I might as well also make the "Don't know" button almost as big as the "Male" and "Female" buttons, as we'd discussed previously.

**Note:** This branch relies on the changes made in the [`issues/105-swipe-up`](https://github.com/everypolitician/gender-balance/tree/issues/105-swipe-up) branch (pull request #171). This PR is set to merge into that branch, but you could just as easily merge into `master` once `issues/105-swipe-up` has been accepted.