### PR TITLE
Google Analytics event tracking for lots of interactions across the site

### DIFF
--- a/public/js/jquery.cardswipe.js
+++ b/public/js/jquery.cardswipe.js
@@ -66,6 +66,10 @@
         // Set up a click listener on each choice's button.
         choiceSettings.$button.on('click', function(){
           self.makeChoice(choiceName);
+
+          if('onButtonPress' in self.settings){
+            self.settings.onButtonPress(self.settings.choices[choiceName].direction);
+          }
         });
       });
 
@@ -74,6 +78,10 @@
         if(e.keyCode in self.keyCodeForChoice){
           var choiceName = self.keyCodeForChoice[e.keyCode];
           self.makeChoice(choiceName);
+
+          if('onKeyboardShortcut' in self.settings){
+            self.settings.onKeyboardShortcut(self.settings.choices[choiceName].direction);
+          }
         }
       });
 
@@ -266,8 +274,14 @@
           if(certainty >= 1){
             if(axis > 0){
               self.makeChoice(self.getChoiceByDirection(positive));
+              if('onSwipe' in self.settings){
+                self.settings.onSwipe(positive);
+              }
             } else {
               self.makeChoice(self.getChoiceByDirection(negative));
+              if('onSwipe' in self.settings){
+                self.settings.onSwipe(negative);
+              }
             }
           } else {
             self.abortChoice();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -116,10 +116,26 @@ $(function(){
 
         updateGoogleLink($stack);
         updateProgressBar();
+      },
+      onKeyboardShortcut: function(direction){
+        ga('send', 'event', 'cardSwipe', 'keyboardShortcut', direction);
+      },
+      onButtonPress: function(direction){
+        ga('send', 'event', 'cardSwipe', 'buttonPress', direction);
+      },
+      onSwipe: function(direction){
+        ga('send', 'event', 'cardSwipe', 'swipe', direction);
       }
+    });
+
+    $('.controls__google a').on('click', function(){
+      ga('send', 'event', 'googleThem', 'click');
     });
   }
 
-  $('[data-filter-elements]').on('keyup', filterElements);
+  $('[data-filter-elements]').on('keyup', filterElements).one('focus', function(){
+    var label = $('label[for="' + $(this).attr('id') + '"]').text();
+    ga('send', 'event', 'filterElements', 'focus', label);
+  });
 
 });


### PR DESCRIPTION
Fixes #93.

Looks like we already had Google Analytics included. This just improves it, to also track the following events:

* Presses on the main in-game buttons.
* Clicks on the "Google them" link.
* Keyboard shortcuts for the in-game buttons (ie: arrow keys).
* Swipes/drags during the game.
* Usage of the filter box on the countries list page.

**Note:** This branch relies on the changes made in the [`issues/105-swipe-up`](https://github.com/everypolitician/gender-balance/tree/issues/105-swipe-up) branch (pull request #171). This PR is set to merge into that branch, but you could just as easily merge into `master` once `issues/105-swipe-up` has been accepted.