### PR TITLE
Fix vagrant provisioning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,8 @@ RuboCop::RakeTask.new
 
 task default: :test
 
+task cache: ['cache:country_person_counts', 'cache:legislative_periods']
+
 namespace :cache do
   task country_person_counts: :app do
     Country.all.each do |country|

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,9 @@ namespace :cache do
       country_count = CountryCount.find_or_create(country_code: country[:code])
       counts = country[:legislatures].map { |l| l[:person_count] }
       country_count.person_count = counts.reduce(:+)
-      country_count.gender_count = country.gender_count
+      if country_count.respond_to?(:gender_count=)
+        country_count.gender_count = country.gender_count
+      end
       country_count.save
     end
   end

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -27,6 +27,7 @@ cd /vagrant
 sudo gem install bundler foreman pry --no-rdoc --no-ri
 bundle install
 bundle exec rake db:migrate
+bundle exec rake cache
 
 # Set shell login message
 echo "-------------------------------------------------------


### PR DESCRIPTION
Because a couple of the migrations manipulate data there is a problem running `vagrant up` on an existing VM. Migration 006 requires the `country_counts` table to be populated, so you'd need to migrate to 005, then run `rake cache:country_person_counts`, then do the rest of the migrations, then run `rake cache` to populate `country_counts.gender_count`. This is only a problem on existing VMs, if you run `vagrant up` without an existing VM then it should work correctly.

This pull requests therefore only addresses issues on fresh vagrant VMs, if you want to preserve an existing VM then you'll either need to step through the migrations and rake tasks in the correct order (describe in the previous paragraph), or alternatively backup your VM's database, `vagrant destroy` it and then `vagrant up` and restore the database.

Fixes #173 