### PR TITLE
Cache counts and legislative periods on webhook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'sinatra-contrib', require: 'sinatra/content_for'
 gem 'yajl-ruby', require: 'yajl'
 gem 'dalli'
 gem 'pry'
+gem 'sidekiq'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,10 @@ GEM
       parser (>= 2.2.0.pre.3, < 3.0)
     backports (3.6.4)
     bacon (1.2.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     coderay (1.1.0)
+    connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     dalli (2.7.4)
@@ -24,6 +27,7 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     hashie (3.4.2)
+    hitimes (1.2.2)
     i18n (0.7.0)
     json (1.8.3)
     jwt (1.5.1)
@@ -81,6 +85,9 @@ GEM
       rack (>= 1.0)
     rainbow (2.0.0)
     rake (10.4.2)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rubocop (0.32.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
@@ -91,6 +98,12 @@ GEM
     safe_yaml (1.0.4)
     sass (3.4.15)
     sequel (4.23.0)
+    sidekiq (3.4.2)
+      celluloid (~> 0.16.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      json (~> 1.0)
+      redis (~> 3.2, >= 3.2.1)
+      redis-namespace (~> 1.5, >= 1.5.2)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -114,6 +127,8 @@ GEM
     slop (3.6.0)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    timers (4.0.1)
+      hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     webmock (1.21.0)
@@ -145,6 +160,7 @@ DEPENDENCIES
   rubocop
   sass
   sequel
+  sidekiq
   simplecov
   sinatra
   sinatra-contrib
@@ -153,4 +169,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -r ./app.rb

--- a/Rakefile
+++ b/Rakefile
@@ -35,39 +35,10 @@ task cache: ['cache:country_person_counts', 'cache:legislative_periods']
 
 namespace :cache do
   task country_person_counts: :app do
-    Country.all.each do |country|
-      puts "Caching person count for #{country[:name]}"
-      country_count = CountryCount.find_or_create(country_code: country[:code])
-      counts = country[:legislatures].map { |l| l[:person_count] }
-      country_count.person_count = counts.reduce(:+)
-      if country_count.respond_to?(:gender_count=)
-        country_count.gender_count = country.gender_count
-      end
-      country_count.save
-    end
+    UpdateCacheJob.new.cache_country_person_counts
   end
 
   task legislative_periods: :app do
-    countries_json = 'https://github.com/everypolitician/' \
-      'everypolitician-data/raw/master/countries.json'
-    countries = Yajl.load(open(countries_json).read, symbolize_keys: true)
-    countries.each do |country|
-      country[:legislatures].each do |legislature|
-        legislature[:legislative_periods].each do |legislative_period|
-          puts "Processing #{country[:name]} #{legislature[:name]} #{legislative_period[:name]}"
-          lp = LegislativePeriod.find_or_create(
-            country_code: country[:code],
-            legislature_slug: legislature[:slug],
-            legislative_period_id: legislative_period[:id]
-          )
-          start_date = legislative_period[:start_date]
-          next if start_date.nil?
-          start_date = "#{start_date}-01-01" if start_date.length == 4
-          lp.start_date = Date.parse(start_date)
-          lp.person_count = lp.unique_people.size
-          lp.save
-        end
-      end
-    end
+    UpdateCacheJob.new.cache_legislative_periods
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -32,6 +32,7 @@ end
 
 require 'helpers'
 require 'app/models'
+require 'app/jobs'
 
 helpers Helpers
 

--- a/app.rb
+++ b/app.rb
@@ -66,6 +66,7 @@ end
 %w(get post).each do |method|
   send(method, '/event_handler') do
     settings.cache_client.delete('countries.json')
+    UpdateCacheJob.perform_async
     'ok'
   end
 end

--- a/app/jobs.rb
+++ b/app/jobs.rb
@@ -1,0 +1,1 @@
+require 'app/jobs/update_cache_job'

--- a/app/jobs/update_cache_job.rb
+++ b/app/jobs/update_cache_job.rb
@@ -1,0 +1,45 @@
+class UpdateCacheJob
+  include Sidekiq::Worker
+
+  def perform
+    cache_country_person_counts
+    cache_legislative_periods
+  end
+
+  def cache_country_person_counts
+    Country.all.each do |country|
+      puts "Caching person count for #{country[:name]}"
+      country_count = CountryCount.find_or_create(country_code: country[:code])
+      counts = country[:legislatures].map { |l| l[:person_count] }
+      country_count.person_count = counts.reduce(:+)
+      if country_count.respond_to?(:gender_count=)
+        country_count.gender_count = country.gender_count
+      end
+      country_count.save
+    end
+  end
+
+  def cache_legislative_periods
+    countries_json = 'https://github.com/everypolitician/' \
+      'everypolitician-data/raw/master/countries.json'
+    countries = Yajl.load(open(countries_json).read, symbolize_keys: true)
+    countries.each do |country|
+      country[:legislatures].each do |legislature|
+        legislature[:legislative_periods].each do |legislative_period|
+          puts "Processing #{country[:name]} #{legislature[:name]} #{legislative_period[:name]}"
+          lp = LegislativePeriod.find_or_create(
+            country_code: country[:code],
+            legislature_slug: legislature[:slug],
+            legislative_period_id: legislative_period[:id]
+          )
+          start_date = legislative_period[:start_date]
+          next if start_date.nil?
+          start_date = "#{start_date}-01-01" if start_date.length == 4
+          lp.start_date = Date.parse(start_date)
+          lp.person_count = lp.unique_people.size
+          lp.save
+        end
+      end
+    end
+  end
+end

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -11,7 +11,7 @@ sudo apt-get update
 # Install required packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ruby2.2 ruby2.2-dev git build-essential libxslt1-dev libssl-dev \
-  postgresql libpq-dev memcached
+  postgresql libpq-dev memcached redis-server
 
 sudo -u postgres createuser --createdb vagrant
 createdb gender_crowdsourcing_development


### PR DESCRIPTION
When we receive a webhook from the app-manager telling us that countries.json has been updated we queue up a job to update the person/gender counts as well as the list of legislative periods.

Fixes #186 