### PR TITLE
Don't render countries with no person/gender counts

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -8,6 +8,7 @@
     <h3 class="list-heading">Your recent countries</h3>
     <div class="list list--countries list--recent">
       <% @recent_countries.each do |country| %>
+        <% next unless country_counts[country[:code]] %>
         <a class="list__item" href="<%= url "/countries/#{country[:slug]}" %>">
           <h3><%= country[:country] %></h3>
           <div class="progress-bar progress-bar--<%= progress_word(percent_complete(country)) %>"><div style="width: <%= percent_complete(country) %>%"></div></div>
@@ -25,6 +26,7 @@
     <h3 class="list-heading">All countries</h3>
     <div class="list list--countries list--all">
       <% @countries.each do |country| %>
+        <% next unless country_counts[country[:code]] %>
         <a class="list__item" href="<%= url "/countries/#{country[:slug]}" %>">
           <h3><%= country[:country] %></h3>
           <div class="progress-bar progress-bar--<%= progress_word(percent_complete(country)) %>"><div style="width: <%= percent_complete(country) %>%"></div></div>


### PR DESCRIPTION
In the main list of countries we don't want to show countries where we
haven't cached the counts for people and number of people that already
have gender.

Once the counts have been cached (which should happen within a minute or
two of a country being added) then the country will display correctly.

Fixes #181 