### PR TITLE
Don't store cache result in a class instance variable

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,6 +1,6 @@
 class Country
   def self.all
-    @countries ||= Sinatra::Application.cache_client.fetch('countries.json') do
+    Sinatra::Application.cache_client.fetch('countries.json') do
       countries_json = 'https://github.com/everypolitician/' \
       'everypolitician-data/raw/master/countries.json'
       countries = Yajl.load(open(countries_json).read, symbolize_keys: true)


### PR DESCRIPTION
This is bad because it means that even when the cache is cleared the
stale cache result is being stored in the instance variable so the new
cache hit won't happen.

Fixes #172 