### PR TITLE
Remove the legislature name from end-of-level screen

### DIFF
--- a/views/term.erb
+++ b/views/term.erb
@@ -20,7 +20,7 @@
       <% if @legislative_period.previous_legislative_period %>
         <% previous_count = @legislative_period.previous_legislative_periods.count %>
         <p>
-            You have completed <b><%= @legislative_period.legislature[:name] %> <%= @legislative_period.name %></b>.
+            You have completed <b><%= @legislative_period.name %></b>.
             There <%= previous_count == 1 ? 'is' : 'are' %>
             <%= previous_count %> more level<%= previous_count == 1 ? '' : 's' %> to play.
         </p>


### PR DESCRIPTION
It’s needless, confusing, and often duplicated in the period name
anyway. Closes #161

![screen shot 2015-07-29 at 09 55 38](https://cloud.githubusercontent.com/assets/57483/8953651/0767b014-35d8-11e5-834e-d589e80df3b3.png)
