### PR TITLE
Less messy login page

### DIFF
--- a/views/login.erb
+++ b/views/login.erb
@@ -1,14 +1,10 @@
-<% content_for :body_class do %>login<% end %>
+<% content_for :body_class do %>login-page<% end %>
 
 <h2 class="page-title">Log in to play</h2>
 
 <p>Logging in only takes 3 seconds — then Gender Balance will remember
 your achievements for the next time you play, unlocking new levels as
 you progress.</p>
-
-<p>It also helps us to ensure good quality submissions, which is
-important because the data produced by Gender Balance will be available
-for researchers, journalists and other analysts to use.</p>
 
 <ul class="login-buttons">
     <li><a class="button button--twitter" href="<%= url '/auth/twitter' %>">Log in with Twitter</a></li>
@@ -18,7 +14,11 @@ for researchers, journalists and other analysts to use.</p>
     <li><a class="button button--github" href="<%= url '/auth/github' %>">Log in with GitHub</a></li>
 </ul>
 
-<h3>The Legal Stuff</h3>
+<p>Logging in also helps us to ensure good quality submissions, which is
+important because the data produced by Gender Balance will be available
+for researchers, journalists and other analysts to use.</p>
+
+<h3 class="page-title">The Legal Stuff</h3>
 
 <p>The data that you generate by using Gender Balance doesn’t belong to
 you. It’ll be placed in the public domain, and free for anyone to use.

--- a/views/sass/_home.scss
+++ b/views/sass/_home.scss
@@ -165,6 +165,10 @@
         padding-left: 340px;
     }
 
+    .home-primary__leaderboard ul {
+        min-height: 7em; // avoids weird overlap if there are fewer than 5 leaders
+    }
+
     .home-primary__screenshot {
         position: absolute;
         bottom: 0;
@@ -201,10 +205,25 @@
     }
 }
 
+.login-page {
+    p {
+        font-size: 0.9em;
+        line-height: 1.5em;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 30em;
+    }
+}
+
 .login-buttons {
     @extend .unstyled-list;
     max-width: 20em;
-    margin: 2em auto 0 auto;
+    margin: 1.5em auto 2em;
+
+    @media (min-height: 700px) {
+        margin-top: 2.5em;
+        margin-bottom: 3em;
+    }
 
     .button {
         display: block;

--- a/views/sass/_typography.scss
+++ b/views/sass/_typography.scss
@@ -21,6 +21,7 @@ a {
 
 .page-title {
     text-align: center;
+    margin-top: 2em;
 
     &:first-child {
         margin-top: 0;


### PR DESCRIPTION
Fixes #200. Text on the login page is now slightly smaller, the login buttons slightly higher, and the line lengths more comfortable on wide screens.

It's still a bit wordy, but unless @MyfanwyNixon fancies shortening the copy, this is ready to go.

![screen shot 2015-07-29 at 10 42 38](https://cloud.githubusercontent.com/assets/739624/8954569/6c030a7c-35de-11e5-949f-ba4a6d66cb12.png)
