### PR TITLE
Only preload the first two images for a game

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -115,7 +115,10 @@ $(function(){
         $card.remove();
         saveResponse(response);
 
-        $('.js-extra-cards').children().eq(0).appendTo($stack);
+        var $newCard = $('.js-extra-cards').children().eq(0);
+        var $newCardImage = $newCard.find('.js-person__picture');
+        $newCardImage.attr('src', $newCardImage.data('src'));
+        $newCard.appendTo($stack);
 
         updateGoogleLink($stack);
         updateProgressBar();

--- a/views/person_partial.erb
+++ b/views/person_partial.erb
@@ -4,7 +4,7 @@
     data-google-link="https://google.com/search?q=<%= person[:name] %> <%= @legislative_period.country[:name] %> <%= @legislative_period.legislature[:name] %>"
 >
   <% if person[:image] %>
-    <img src="https://everypolitician-image-proxy.herokuapp.com/<%= URI.encode_www_form_component(person[:image]) %>/140/140.jpg" class="person__picture">
+    <img <%= 'data-' unless preload_image %>src="https://everypolitician-image-proxy.herokuapp.com/<%= URI.encode_www_form_component(person[:image]) %>/140/140.jpg" class="person__picture js-person__picture">
   <% else %>
     <img src="/img/person.png" class="person__picture">
   <% end %>

--- a/views/term.erb
+++ b/views/term.erb
@@ -11,7 +11,7 @@
 <div class="person-cards">
     <ul class="js-cardswipe">
         <% @people.take(2).each do |person| %>
-            <%= erb :person_partial, locals: { person: person } %>
+            <%= erb :person_partial, locals: { person: person, preload_image: true } %>
         <% end %>
     </ul>
     <div class="level-complete">
@@ -51,7 +51,7 @@
 
 <ul class="js-extra-cards" style="display: none">
     <% @people.drop(2).each do |person| %>
-        <%= erb :person_partial, locals: { person: person } %>
+        <%= erb :person_partial, locals: { person: person, preload_image: false } %>
     <% end %>
 </ul>
 


### PR DESCRIPTION
For large terms preloading all of the images slows things down
significantly. So instead of preloading them all we just preload the
first two visible images. The rest of the images have the 'src'
attribute in a 'data-src' attribute, which then gets copied across when
it's added to the back of the stack.

Fixes #187 