### PR TITLE
Show button feedback even when swiping/keyboarding

### DIFF
--- a/public/js/jquery.cardswipe.js
+++ b/public/js/jquery.cardswipe.js
@@ -14,10 +14,12 @@
   // Set up variables common to all instances of the plugin.
   var pluginName = "cardSwipe";
   var defaults = {
-    onChoiceMade: function(choice, $card, $stack){
+    onChoiceMade: function(choice, $card, $button, $stack, animateCurrentCard){
       // Hopefully the user will replace this function
       // with something more useful!
-      $card.remove();
+      animateCurrentCard(function(){
+        $card.remove();
+      });
     },
     $keyListenerContext: $(document),
     keyCodeForDirection: {
@@ -173,16 +175,24 @@
         var animationSpeed = self.settings.animationSpeed / 2;
       }
 
-      $currentCard.animate(
-        animateToCss,
-        animationSpeed,
-        function(){
-          self.settings.onChoiceMade(
-            choiceName,
-            self.getCurrentCard(),
-            self.$element
-          );
-        }
+      // User-specified onChoiceMade functions should call this to
+      // animate the current card off the stack. They can supply a
+      // callback in onAnimationComplete, to be run after the
+      // animation has finished.
+      var animateCurrentCard = function(onAnimationComplete){
+        $currentCard.addClass('animating').animate(
+          animateToCss,
+          animationSpeed,
+          onAnimationComplete
+        );
+      }
+
+      self.settings.onChoiceMade(
+        choiceName,
+        self.getCurrentCard(),
+        choiceSettings.$button,
+        self.$element,
+        animateCurrentCard
       );
     },
 

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -114,8 +114,20 @@
 </ul>
 
 <div class="controls">
-    <div class="controls__skip js-choose-dontknow" href="#">Don’t know</div>
-    <div class="controls__male js-choose-male" href="#">Male</div>
-    <div class="controls__female js-choose-female" href="#">Female</div>
-    <div class="controls__other js-choose-other" href="#">Other</div>
+    <div class="controls__skip js-choose-dontknow">
+        Don’t know
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__male js-choose-male">
+        Male
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__female js-choose-female">
+        Female
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__other js-choose-other">
+        Other
+        <div class="js-click-animation"></div>
+    </div>
 </div>

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -46,7 +46,7 @@ body.person-page {
     box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 
     position: absolute;
-    z-index: 2;
+    z-index: 3;
     top: 0;
     left: 50%;
     width: 16em;
@@ -84,6 +84,11 @@ body.person-page {
         height: 15em;
     }
 
+    @media (min-width: $screen_small_min) {
+        width: 18em;
+        margin-left: -9em;
+    }
+
     &:first-child {
         cursor: move;
         cursor: -webkit-grab;
@@ -104,10 +109,7 @@ body.person-page {
         }
     }
 
-    & > * {
-        margin: 0;
-    }
-
+    // Cards after the first one should look smaller and greyer...
     & + & {
         z-index: 1;
         font-size: 0.95em;
@@ -115,9 +117,16 @@ body.person-page {
         background-color: mix($color_white, #eee, 50%);
     }
 
-    @media (min-width: $screen_small_min) {
-        width: 18em;
-        margin-left: -9em;
+    // ...Unless the first card is animating
+    &.animating + & {
+        z-index: 2;
+        font-size: 1em;
+        top: 0;
+        background-color: $color_white;
+    }
+
+    & > * {
+        margin: 0;
     }
 }
 
@@ -324,6 +333,19 @@ body.person-page {
     &:focus {
         color: $color_white;
     }
+
+    .js-click-animation {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: -1; // behind the parent element (the button)
+        border-radius: inherit;
+        background-color: inherit;
+        opacity: 0.3;
+        display: none; // will be shown with javascript
+    }
 }
 
 .controls__male,
@@ -341,10 +363,6 @@ body.person-page {
     &:hover,
     &:focus {
         background-color: darken($color_orange, 5%);
-    }
-
-    &:active {
-        margin-bottom: -0.2em;
     }
 }
 
@@ -373,10 +391,6 @@ body.person-page {
     &:hover,
     &:focus {
         background-color: darken($color_grey, 5%);
-    }
-
-    &:active {
-        margin-bottom: -0.2em;
     }
 }
 

--- a/views/term.erb
+++ b/views/term.erb
@@ -56,10 +56,22 @@
 </ul>
 
 <div class="controls js-controls">
-    <div class="controls__skip js-choose-dontknow" href="#">Don’t<br>know</div>
-    <div class="controls__male js-choose-male" href="#">Male</div>
-    <div class="controls__female js-choose-female" href="#">Female</div>
-    <div class="controls__other js-choose-other" href="#">Other</div>
+    <div class="controls__skip js-choose-dontknow">
+        Don’t know
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__male js-choose-male">
+        Male
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__female js-choose-female">
+        Female
+        <div class="js-click-animation"></div>
+    </div>
+    <div class="controls__other js-choose-other">
+        Other
+        <div class="js-click-animation"></div>
+    </div>
     <span class="controls__google">Not sure? <a class="js-google-link" href="#" target="_blank"><i class="fa fa-search"></i>Google them!</a></span>
 </div>
 


### PR DESCRIPTION
Fixes #198 by showing a pretty feedback animation behind buttons no matter how the card was chosen.

Also fixes #116 by replacing the `margin-bottom` CSS bug that was causing click handlers to not fire in some circumstances.

Also fixes a few other CSS display bugs to do with the card stacking, which would occasionally make it look like new cards added to the stack were jumping to the front of the pack rather than the back.

Oh, and we now initiate a lot of the post-card-selection logic (eg: updating the progress bar, saving the ajax response) *during* the outgoing card animation, rather than after, which helps make things feel a lot faster.