### PR TITLE
Display a friendly error after failed auth attempt

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -102,8 +102,9 @@ end
 end
 
 get '/auth/failure' do
-  flash[:notice] = params[:message]
-  redirect '/'
+  logger.info "Auth failure: #{params[:message]}"
+  flash[:notice] = "There was a problem authenticating you. Please try again."
+  redirect '/login'
 end
 
 get '/onboarding' do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -58,7 +58,7 @@ describe 'App' do
         OmniAuth.config.mock_auth[:twitter] = :invalid_credentials
         get '/auth/twitter'
         3.times { follow_redirect! }
-        assert last_response.body.include?('invalid_credentials')
+        assert last_response.body.include?('There was a problem authenticating you. Please try again.')
       end
     end
 


### PR DESCRIPTION
When authentication fails set a friendly error message and take the user
back to the login screen. The actual error still gets logged to the
console, but is usually something unfriendly so not worth displaying to
the user.

Fixes #180 