### PR TITLE
Update Google link and progress bar async

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -159,6 +159,10 @@ $(function(){
         // While response is being saved, animate and then remove the top card...
         animateCurrentCard(function(){
           $card.remove();
+
+          // ...And update the various bits of UI relating to the current card
+          updateGoogleLink($stack);
+          updateProgressBar();
         });
 
         // ...Append a new card to the bottom of the stack...
@@ -166,10 +170,6 @@ $(function(){
         var $newCardImage = $newCard.find('.js-person__picture');
         $newCardImage.attr('src', $newCardImage.data('src'));
         $newCard.appendTo($stack);
-
-        // ...And update the various bits of UI relating to the current card
-        updateGoogleLink($stack);
-        updateProgressBar();
 
       },
       onKeyboardShortcut: function(direction){


### PR DESCRIPTION
Now the card gets removed in the animateCurrentCard callback we need to
move the google link and progress bar bits in there as well because they
operate on the assumption that the card has been removed from the DOM at
the point where they run.

Fixes #222 