### PR TITLE
Hide level completion message with CSS, not JavaScript

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -172,7 +172,6 @@ $(function(){
       },
       onInit: function($stack){
         updateGoogleLink($stack);
-        $('.level-complete').hide();
       }
     });
 

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -25,7 +25,7 @@
             <span class="person__decision person__decision--dontknow js-overlay-dontknow"></span>
         </li>
     </ul>
-    <div class="level-complete">
+    <div class="level-complete level-complete--hidden">
         <div class="trophy">
             <img src="/img/winners-trophy.png" width="180" height="240" alt="">
             <div class="trophy__flash"></div>

--- a/views/sass/_person.scss
+++ b/views/sass/_person.scss
@@ -300,6 +300,10 @@ body.person-page {
     }
 }
 
+.level-complete--hidden {
+    display: none;
+}
+
 .controls {
     position: absolute;
     bottom: 0.5em;

--- a/views/term.erb
+++ b/views/term.erb
@@ -14,7 +14,7 @@
             <%= erb :person_partial, locals: { person: person, preload_image: true } %>
         <% end %>
     </ul>
-    <div class="level-complete">
+    <div class="level-complete level-complete--hidden">
         <div class="trophy">
             <img src="/img/winners-trophy.png" width="180" height="240" alt="">
             <div class="trophy__flash"></div>


### PR DESCRIPTION
Fixes #226 and avoids the message briefly flashing up before the
JavaScript kicks in.