### PR TITLE
Explicitly sort the list of countries

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -4,7 +4,7 @@ class Country
       countries_json = 'https://github.com/everypolitician/' \
       'everypolitician-data/raw/master/countries.json'
       countries = Yajl.load(open(countries_json).read, symbolize_keys: true)
-      countries.map { |country| Country.new(country) }
+      countries.sort_by { |c| c[:name] }.map { |country| Country.new(country) }
     end
   end
 


### PR DESCRIPTION
Rather than relying on the order they come out of EveryPolitician we
explicitly sort them before caching them.

Fixes #129 