### PR TITLE
Handle changing legislative period ids

### DIFF
--- a/app/jobs/update_cache_job.rb
+++ b/app/jobs/update_cache_job.rb
@@ -20,10 +20,8 @@ class UpdateCacheJob
   end
 
   def cache_legislative_periods
-    countries_json = 'https://github.com/everypolitician/' \
-      'everypolitician-data/raw/master/countries.json'
-    countries = Yajl.load(open(countries_json).read, symbolize_keys: true)
-    countries.each do |country|
+    LegislativePeriod.enabled.each { |lp| lp.disable! if lp.missing? }
+    Country.all.each do |country|
       country[:legislatures].each do |legislature|
         legislature[:legislative_periods].each do |legislative_period|
           puts "Processing #{country[:name]} #{legislature[:name]} #{legislative_period[:name]}"

--- a/app/models/legislative_period.rb
+++ b/app/models/legislative_period.rb
@@ -5,6 +5,10 @@ class LegislativePeriod < Sequel::Model
     def for_country_code(country_code)
       where(country_code: country_code).order(Sequel.desc(:start_date))
     end
+
+    def enabled
+      where(disabled: false)
+    end
   end
 
   def name
@@ -55,6 +59,7 @@ class LegislativePeriod < Sequel::Model
 
   def previous_legislative_periods
     LegislativePeriod
+      .enabled
       .where(country_code: country[:code], legislature_slug: legislature[:slug])
       .order(Sequel.desc(:start_date))
       .where('start_date < ?', start_date)

--- a/app/models/legislative_period.rb
+++ b/app/models/legislative_period.rb
@@ -11,6 +11,15 @@ class LegislativePeriod < Sequel::Model
     end
   end
 
+  def missing?
+    legislative_period.nil?
+  end
+
+  def disable!
+    self.disabled = true
+    save
+  end
+
   def name
     legislative_period[:name]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < Sequel::Model
   end
 
   def legislative_periods_for(country, legislature)
-    LegislativePeriod.where(country_code: country[:code], legislature_slug: legislature[:slug]).order(Sequel.desc(:start_date))
+    LegislativePeriod.enabled.where(country_code: country[:code], legislature_slug: legislature[:slug]).order(Sequel.desc(:start_date))
   end
 
   def last_response_for(country, legislature)

--- a/db/migrations/010_add_disabled_flag_to_legislative_periods.rb
+++ b/db/migrations/010_add_disabled_flag_to_legislative_periods.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:legislative_periods) do
+      add_column :disabled, TrueClass, default: false
+    end
+  end
+end


### PR DESCRIPTION
When a legislative period id changes we disable the old legislative period during the caching.

Need to manually run `rake db:migrate` and the `rake cache` after this has been deployed.

Fixes #204 
Fixes #249 