### PR TITLE
Add an undo button

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -50,7 +50,7 @@
             <div class="app-header">
                 <%= yield_content :back_button %>
                 <h1>Gender Balance</h1>
-                <%= yield_content :forward_button %>
+                <%= yield_content :undo_button %>
             </div>
             <div class="app-content">
                 <%= yield %>

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -4,6 +4,12 @@
     <a class="app-header__back" href="/"><i class="fa fa-chevron-left"></i></a>
 <% end %>
 
+<% content_for :undo_button do %>
+    <div class="app-header__undo button button--undo js-undo">
+        Undo
+    </div>
+<% end %>
+
 <div class="progress-bar progress-bar--healthy" data-total="12"><div style="width: 0%"></div></div>
 
 <div class="person-cards">
@@ -144,6 +150,8 @@
         <span class="person__decision person__decision--dontknow js-overlay-dontknow"></span>
     </li>
 </ul>
+
+<ul class="js-done-stack" style="display: none"></ul>
 
 <div class="controls js-controls">
     <div class="controls__skip js-choose-dontknow">

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -63,6 +63,10 @@
     @include make_button($color_orange, $color_white);
 }
 
+.button--undo {
+    @include make_button($color_grey, $color_white);
+}
+
 .button__social-icon {
     font-size: 1.2em;
     margin: -0.2em 0.7em -0.2em 0;

--- a/views/sass/_header.scss
+++ b/views/sass/_header.scss
@@ -19,15 +19,22 @@
 }
 
 .app-header__back,
-.app-header__forward {
+.app-header__undo {
     position: absolute;
     text-decoration: none;
     font-size: 0.9em;
     padding: 0.5em;
-    top: 0;
 
     @media (min-width: $screen_medium_min) {
         font-size: 1em;
+    }
+}
+
+.app-header__back {
+    left: 0;
+    top: 0;
+
+    @media (min-width: $screen_medium_min) {
         top: -0.5em;
     }
 
@@ -36,10 +43,13 @@
     }
 }
 
-.app-header__back {
-    left: 0;
-}
+.app-header__undo {
+    cursor: pointer;
+    right: 2px;
+    top: 2px;
 
-.app-header__forward {
-    right: 0;
+    @media (min-width: $screen_medium_min) {
+        right: 0;
+        top: -0.5em;
+    }
 }

--- a/views/term.erb
+++ b/views/term.erb
@@ -4,6 +4,12 @@
     <a class="app-header__back" href="<%= url "/countries" %>"><i class="fa fa-chevron-left"></i></a>
 <% end %>
 
+<% content_for :undo_button do %>
+    <div class="app-header__undo button button--undo js-undo">
+        Undo
+    </div>
+<% end %>
+
 <% if @people.any? %>
 
 <div class="progress-bar progress-bar--healthy" data-total="<%= @legislative_period.unique_people.size %>"><div style="width: <%= percent_complete_term(@legislative_period) %>%"></div></div>
@@ -58,6 +64,8 @@
         <%= erb :person_partial, locals: { person: person, preload_image: false } %>
     <% end %>
 </ul>
+
+<ul class="js-done-stack" style="display: none"></ul>
 
 <div class="controls js-controls">
     <div class="controls__skip js-choose-dontknow">


### PR DESCRIPTION
Adds an undo button to the interface (though it possibly looks a bit ugly):
![screen shot 2015-08-20 at 17 36 24](https://cloud.githubusercontent.com/assets/464193/9389277/1262f00a-4762-11e5-8a7e-e351d0c82b6b.png)

Cards are moved onto a done stack once they’re sorted. They’re moved off it again when the undo button is pressed. No API calls are currently made when undo is pressed – instead, the user just gets a second chance to classify the card. This is presumably okay, because you can currently classify a card multiple times anyway (by pressing buttons in quick succession).

Fixes #30.