### PR TITLE
Simplify the event_handler endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,12 +68,10 @@ get '/about' do
   erb :about
 end
 
-%w(get post).each do |method|
-  send(method, '/event_handler') do
-    settings.cache_client.delete('countries.json')
-    UpdateCacheJob.perform_async
-    'ok'
-  end
+post '/event_handler' do
+  settings.cache_client.delete('countries.json')
+  UpdateCacheJob.perform_async
+  'ok'
 end
 
 get '/logout' do


### PR DESCRIPTION
The requests to the /event_handler endpoint are only sent as `POST` requests, so there's no reason for it to handle `GET` requests.