### PR TITLE
Fix Hungary errors and tidy a few bits up

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -140,7 +140,6 @@ end
 
 get '/countries/:country/legislatures/:legislature' do
   @country = Country.find_by_slug(params[:country])
-  country_count = country_counts[@country[:code]]
   @legislature = @country.legislature(params[:legislature])
   @legislative_period = current_user.legislative_period_for(@country, @legislature)
   return erb :congratulations unless @legislative_period

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < Sequel::Model
       )
       .map(:politician_id)
     people = people.reject { |person| already_done.include?(person[:id]) }
-    people.uniq { |p| p[:id] }.shuffle
+    people.shuffle
   end
 
   def legislative_periods_for(country, legislature)

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -30,7 +30,8 @@ module Helpers
           .where(country_code: country[:code])
           .distinct
           .count
-        (complete_people.to_f / total_people.to_f) * 100
+        total = (complete_people.to_f / total_people.to_f) * 100
+        total < 100 ? total : 100
       end
   end
 
@@ -45,7 +46,8 @@ module Helpers
         legislature_slug: legislative_period.legislature[:slug],
         country_code: legislative_period.country_code
       ).count
-    (response_count.to_f / total_people.to_f) * 100
+    total = (response_count.to_f / total_people.to_f) * 100
+    total < 100 ? total : 100
   end
 
   def progress_word(percent)


### PR DESCRIPTION
- Drastically simplify legislative period finding, we now simply scan for an `incomplete?` legislature, which is one where there are still some people to categorise. We don't bother looking for the last response etc anymore as that just causes problems when terms change id or disappear.
- Don't allow progress bars to go over 100% - sometimes they do for one reason or another, so I've hard coded a fix for this in the % calculations.
- Remove some code that's either dead or unnecessary.

Fixes #267 