### PR TITLE
Escape double quotes in person name and ID

### DIFF
--- a/views/person_partial.erb
+++ b/views/person_partial.erb
@@ -1,7 +1,7 @@
 <li class="person-card person-card--person"
-    data-politician_id="<%= person[:id] %>"
+    data-politician_id="<%== person[:id] %>"
     data-legislative_period_id="<%= @legislative_period.id %>"
-    data-google-link="https://google.com/search?q=<%= person[:name] %> <%= @legislative_period.country[:name] %> <%= @legislative_period.legislature[:name] %>"
+    data-google-link="https://google.com/search?q=<%== person[:name] %> <%= @legislative_period.country[:name] %> <%= @legislative_period.legislature[:name] %>"
 >
   <% if person[:image] %>
     <img <%= 'data-' unless preload_image %>src="https://mysociety.github.io/politician-image-proxy/<%= @country[:slug] %>/<%= @legislature[:slug] %>/<%= URI.encode_www_form_component(person[:id]) %>/140x140.jpeg" class="person__picture js-person__picture">


### PR DESCRIPTION
I’m not exactly sure if/why this is correct! It seems to work, though.

Fixes #281 & #279.