### PR TITLE
Don't show complete legislatures on country page

### DIFF
--- a/views/country.erb
+++ b/views/country.erb
@@ -6,10 +6,12 @@
 
 <% @country[:legislatures].each do |legislature| %>
 
+  <% if current_user.legislative_period_for(@country, legislature) %>
     <div class="list list--terms">
         <a class="list__item" href="<%= url "/countries/#{params[:country]}/legislatures/#{legislature[:slug]}" %>">
             <h3><%= legislature[:name] %></h3>
         </a>
     </div>
+  <% end %>
 
 <% end %>


### PR DESCRIPTION
This skips over any legislatures that have already been played to
completion so they aren't shown on the countries screen.

Fixes #214 