### PR TITLE
Overwrite existing responses after undo has been used

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -158,7 +158,7 @@ end
 
 post '/responses' do
   begin
-    current_user.add_response(params[:response])
+    current_user.record_response(params[:response])
     'ok'
   rescue Sequel::UniqueConstraintViolation
     halt 403, 'Decision already recorded for this politician'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,4 +53,14 @@ class User < Sequel::Model
       .where{responses__created_at < featured_country.end_date}
       .any?
   end
+
+  def record_response(response)
+    db.transaction do
+      responses_dataset.where(
+        legislative_period_id: response[:legislative_period_id],
+        politician_id: response[:politician_id]
+      ).delete
+      add_response(response)
+    end
+  end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe User do
+  describe '#record_response' do
+    let(:legislative_period) do
+      LegislativePeriod.create(
+        country_code: 'FOO',
+        legislature_slug: '123',
+        legislative_period_id: '123'
+      )
+    end
+    subject { User.create(name: 'Test', uid: '123', provider: 'twitter') }
+
+    it "shouldn't allow two responses for the same person" do
+      subject.record_response(
+        legislative_period_id: legislative_period.id,
+        politician_id: 'alice',
+        choice: 'female'
+      )
+      assert_equal 1, subject.responses_dataset.count
+      5.times do
+        subject.record_response(
+          legislative_period_id: legislative_period.id,
+          politician_id: 'bob',
+          choice: 'male'
+        )
+      end
+      assert_equal 2, subject.responses_dataset.count
+    end
+  end
+end


### PR DESCRIPTION
If a played uses the undo button then we remove the existing reponse for
that politician and create a new one. This means that they don't get the
score for that politician counted twice.

Fixes #261 