### PR TITLE
Show a hint on countries page for brand new users

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -4,7 +4,12 @@
 
 <h2 class="page-title">Pick a country</h2>
 
-  <% if @featured_country %>
+  <% if not current_user.responses.any? %>
+    <div style="text-align: center">
+      <p>Which country’s politicians would you like to categorise&nbsp;first?</p>
+      <p style="font-style: italic">(Maybe try searching for your home&nbsp;country…)</p>
+    </div>
+  <% elsif @featured_country %>
     <h3 class="list-heading">Featured country</h3>
     <p>
     <% if percent_complete(@featured_country) >= 100 %>
@@ -42,7 +47,7 @@
   <% end %>
 
   <div class="filter-countries">
-      <label for="filter">Filter countries</label>
+      <label for="filter">Find a country</label>
       <input type="text" id="filter" data-filter-elements=".list--all .list__item">
   </div>
 

--- a/views/countries.erb
+++ b/views/countries.erb
@@ -6,8 +6,8 @@
 
   <% if not current_user.responses.any? %>
     <div style="text-align: center">
-      <p>Which country’s politicians would you like to categorise&nbsp;first?</p>
-      <p style="font-style: italic">(Maybe try searching for your home&nbsp;country…)</p>
+      <p>Which country’s politicians would you like to try&nbsp;first?</p>
+      <p style="font-style: italic">(Maybe search for your home&nbsp;country…)</p>
     </div>
   <% elsif @featured_country %>
     <h3 class="list-heading">Featured country</h3>


### PR DESCRIPTION
Fixes #238 by showing brand new users (ie: fresh out of the
OAuth dance) a message explaining that they should pick a
country to play, and maybe they’d like to start with their
home country.

![screen shot 2015-10-15 at 17 09 30](https://cloud.githubusercontent.com/assets/739624/10519919/cd04fd94-735f-11e5-8775-127d25c82d70.png)
