### PR TITLE
Tidy up Undo button styling

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -17,6 +17,15 @@ var updateGoogleLink = function updateGoogleLink($stack){
   $('.js-google-link').attr('href', link);
 }
 
+var updateUndoButton = function updateUndoButton(){
+  var $el = $('.js-undo');
+  if ($('.js-done-stack').children().length == 0) {
+    $el.addClass('button--disabled');
+  } else {
+    $el.removeClass('button--disabled');
+  }
+}
+
 var undo = function undo(cardSwipe, $stack){
   var $latestCard = $('.js-done-stack').children().eq(0);
   if ($latestCard.length === 0) return;
@@ -43,9 +52,7 @@ var undo = function undo(cardSwipe, $stack){
   function() {
     updateGoogleLink($stack);
     updateProgressBar();
-    if ($('.js-done-stack').children().length == 0) {
-      $('.js-undo').addClass('button--disabled');
-    }
+    updateUndoButton();
   });
 }
 
@@ -195,12 +202,10 @@ $(function(){
           var $doneStack = $('.js-done-stack');
           $card.removeClass('animating').remove().prependTo($doneStack);
 
-          // Enable the undo button now there are cards on the doneStack
-          $('.js-undo').removeClass('button--disabled');
-
           // ...And update the various bits of UI relating to the current card
           updateGoogleLink($stack);
           updateProgressBar();
+          updateUndoButton();
         });
 
         // ...Append a new card to the bottom of the stack...

--- a/views/onboarding.erb
+++ b/views/onboarding.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :undo_button do %>
-    <div class="app-header__undo button button--undo button--disabled js-undo">
+    <div class="app-header__undo button button--disabled js-undo">
         Undo
     </div>
 <% end %>

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -63,13 +63,9 @@
     @include make_button($color_orange, $color_white);
 }
 
-.button--undo {
-    @include make_button($color_grey, $color_white);
-}
-
 .button--disabled {
     color: lighten($color_grey, 5%);
-    background-color: $color_grey;
+    background: transparent;
 
     cursor: default !important;
 
@@ -77,7 +73,7 @@
     &:active,
     &:focus {
         color: lighten($color_grey, 5%);
-        background-color: $color_grey;
+        background: transparent;
     }
 }
 

--- a/views/term.erb
+++ b/views/term.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :undo_button do %>
-    <div class="app-header__undo button button--undo button--disabled js-undo">
+    <div class="app-header__undo button button--disabled js-undo">
         Undo
     </div>
 <% end %>


### PR DESCRIPTION
The thick grey button never looked very comfortable in the app header bar. A blue link matches the back arrow.

Also DRY-ed up some of the javascript code, by creating an `updateUndoButton` function that acts similarly to `updateProgressBar` etc.

Mobile:

![undo](https://cloud.githubusercontent.com/assets/739624/10729710/2bd9119e-7be3-11e5-9a9f-086e2e72f35c.gif)

Desktop: 

![screen shot 2015-10-26 at 13 12 47](https://cloud.githubusercontent.com/assets/739624/10729745/57633c5e-7be3-11e5-9159-ee1da265a829.png)
