### PR TITLE
Switch to monthly leaderboard

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -65,7 +65,7 @@ class Response < Sequel::Model
         .group(:users__id, :users__name)
         .order(Sequel.desc(:count))
         .limit(limit)
-        .where{responses__created_at > 1.week.ago}
+        .where{responses__created_at > 1.month.ago}
     end
   end
 end

--- a/views/leaderboard.erb
+++ b/views/leaderboard.erb
@@ -1,5 +1,5 @@
 <div class="home-primary__leaderboard">
-    <h3>Top players this week</h3>
+    <h3>Top players this month</h3>
     <ul class="home-primary__leaderboard__top-5">
     <% @leaders.take(5).each do |leader| %>
       <li><%= leader[:name].split(/[[:space:]]+/).first %> <span class="leaderboard-score"><%= leader[:count] %></span></li>


### PR DESCRIPTION
Rather than showing the top players in the last week, show them for the
last month.