### PR TITLE
Legacy id mapping

### DIFF
--- a/lib/legacy_id_mapper.rb
+++ b/lib/legacy_id_mapper.rb
@@ -1,0 +1,18 @@
+# Maps new EveryPolitician UUIDs to legacy ids
+class LegacyIdMapper
+  def initialize(popolo)
+    id_mapping = popolo[:persons].map do |person|
+      next unless person[:identifiers]
+      legacy_id = person[:identifiers].find do |i|
+        i[:scheme] == 'everypolitician_legacy'
+      end
+      next unless legacy_id
+      [person[:id], legacy_id[:identifier]]
+    end
+    @map = Hash[id_mapping.compact]
+  end
+
+  def [](id)
+    @map.fetch(id, id)
+  end
+end

--- a/spec/legacy_id_mapper_spec.rb
+++ b/spec/legacy_id_mapper_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe LegacyIdMapper do
+  let(:popolo) do
+    {
+      persons: [
+        {
+          id: 'af3e71ab-01f9-4190-a988-79944eeed8e7',
+          identifiers: [
+            { scheme: 'everypolitician_legacy', identifier: 'bob' }
+          ]
+        },
+        {
+          id: 'another-uuid',
+          identifiers: [
+            { scheme: 'everypolitician_legacy', identifier: 'john-smith' }
+          ]
+        },
+        {
+          id: 'new-uuid'
+        },
+        {
+          id: 'person/alice'
+        }
+      ]
+    }
+  end
+
+  subject { LegacyIdMapper.new(popolo) }
+
+  it 'maps the new id to the everypolitician_legacy identifier' do
+    assert_equal 'bob', subject['af3e71ab-01f9-4190-a988-79944eeed8e7']
+    assert_equal 'john-smith', subject['another-uuid']
+  end
+
+  it "returns the given id if there's no legacy id" do
+    assert_equal 'new-uuid', subject['new-uuid']
+  end
+
+  it 'returns the id unchanged if not found in the source data' do
+    assert_equal 'alice', subject['alice']
+    assert_equal 'missing', subject['missing']
+  end
+end


### PR DESCRIPTION
EveryPolitician is switching to use UUIDs in https://github.com/everypolitician/everypolitician-data/pull/1155, which would mean that all existing GenderBalance scores would be lost. To prevent losing existing data this PR introduces a way of mapping new UUIDs back to the legacy id that we're currently using in GenderBalance. It will continue to work when new countries and legislatures are added as if it doesn't find a legacy id it will just use the current id.