### PR TITLE
Remove duplicate votes (responses) from GenderBalance

### DIFF
--- a/db/migrations/012_delete_duplicate_responses.rb
+++ b/db/migrations/012_delete_duplicate_responses.rb
@@ -1,0 +1,24 @@
+Sequel.migration do
+  up do
+    remove_duplicate_responses_sql = <<-SQL
+DELETE FROM responses
+WHERE (user_id, politician_id, created_at) NOT IN (
+  SELECT user_id, politician_id, max(created_at)
+  FROM responses
+  GROUP BY user_id, politician_id
+)
+    SQL
+    run(remove_duplicate_responses_sql)
+
+    # Now add an index to prevent more duplicate responses.
+    alter_table(:responses) do
+      add_index [:user_id, :politician_id], unique: true
+    end
+  end
+
+  down do
+    alter_table(:responses) do
+      drop_index [:user_id, :politician_id]
+    end
+  end
+end

--- a/spec/csv_export_spec.rb
+++ b/spec/csv_export_spec.rb
@@ -36,25 +36,4 @@ describe CsvExport do
     actual = CSV.parse(subject.to_csv, headers: true)
     assert_equal expected, actual.map(&:to_hash)
   end
-
-  describe 'with duplicate responses' do
-    before do
-      Response.create(
-        user_id: user.id,
-        politician_id: "politician2",
-        legislative_period_id: legislative_period.id,
-        choice: 'skip'
-      )
-    end
-
-    it "doesn't count votes twice" do
-      expected = [
-        {"uuid"=>"pol1", "female"=>nil, "male"=>"1", "other"=>nil, "skip"=>nil, "total"=>"1"},
-        {"uuid"=>"pol2", "female"=>nil, "male"=>nil, "other"=>nil, "skip"=>"1", "total"=>"1"},
-        {"uuid"=>"pol3", "female"=>"1", "male"=>nil, "other"=>nil, "skip"=>nil, "total"=>"1"}
-      ]
-      actual = CSV.parse(subject.to_csv, headers: true)
-      assert_equal expected, actual.map(&:to_hash)
-    end
-  end
 end


### PR DESCRIPTION
Up until now there was no unique constraint on (user_id, politician_id)
for the responses table. This has resulted in people voting for
politicians gender more than once. This makes it tricky to do things
such as calculate voting patterns and see if there has been a consensus
for a country.

Fixes #296 