### PR TITLE
Votes migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,3 +42,10 @@ namespace :cache do
     UpdateCacheJob.new.cache_legislative_periods
   end
 end
+
+task add_country_slug_to_featured_countries: :app do
+  FeaturedCountry.each do |fc|
+    country = Everypolitician.country(code: fc.country_code)
+    fc.update(country_slug: country.slug)
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,23 @@ task add_country_slug_to_featured_countries: :app do
   end
 end
 
+task create_country_uuids: :app do
+  db = Sinatra::Application.database
+  Everypolitician.countries.each do |country|
+    country.legislatures.each do |legislature|
+      puts "Creating country_uuids rows for #{country.name} - #{legislature.name}"
+      legislature.popolo.persons.each do |person|
+        db[:country_uuids].insert(
+          country_slug: country.slug,
+          legislature_slug: legislature.slug,
+          uuid: person[:id],
+          created_at: DateTime.now
+        )
+      end
+    end
+  end
+end
+
 def id_mapper(country_code, legislature_slug)
   @mappers ||= {}
   @mappers[country_code] ||= {}

--- a/Rakefile
+++ b/Rakefile
@@ -98,3 +98,10 @@ task migrate_responses_to_votes: :app do
     end
   end
 end
+
+desc 'Perform steps necessary for switching from responses to votes'
+task :votes do
+  Rake::Task['create_country_uuids'].invoke
+  Rake::Task['add_country_slug_to_featured_countries'].invoke
+  Rake::Task['migrate_responses_to_votes'].invoke
+end

--- a/app/models/featured_country.rb
+++ b/app/models/featured_country.rb
@@ -15,7 +15,8 @@ class FeaturedCountry < Sequel::Model
           raise ArgumentError, "This country has already been featured. See http://git.io/vcO2x"
         end
         FeaturedCountry.create(
-          country_code: country[:code],
+          country_code: country.code,
+          country_slug: country.slug,
           start_date: DateTime.now,
           end_date: 1.month.from_now
         )

--- a/db/migrations/012_create_votes.rb
+++ b/db/migrations/012_create_votes.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table(:votes) do
+      primary_key :id
+      foreign_key :user_id, :users, null: false, index: true
+      String :person_uuid, null: false
+      String :choice, null: false
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end

--- a/db/migrations/013_enforce_unique_votes.rb
+++ b/db/migrations/013_enforce_unique_votes.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:votes) do
+      add_index [:user_id, :person_uuid], unique: true
+    end
+  end
+end

--- a/db/migrations/014_create_country_uuids.rb
+++ b/db/migrations/014_create_country_uuids.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table(:country_uuids) do
+      primary_key :id
+      String :uuid, null: false
+      String :country_slug, null: false
+      DateTime :created_at
+      DateTime :updated_at
+      unique [:uuid, :country_slug]
+    end
+  end
+end

--- a/db/migrations/015_add_country_slug_to_featured_countries.rb
+++ b/db/migrations/015_add_country_slug_to_featured_countries.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:featured_countries) do
+      add_column :country_slug, String
+    end
+  end
+end

--- a/db/migrations/016_add_legislature_slug_to_country_uuids.rb
+++ b/db/migrations/016_add_legislature_slug_to_country_uuids.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    alter_table(:country_uuids) do
+      add_column :legislature_slug, String, null: false
+      drop_constraint :country_uuids_uuid_country_slug_key
+      add_unique_constraint [:uuid, :country_slug, :legislature_slug]
+    end
+  end
+end


### PR DESCRIPTION
This is the first half of #313, just containing the database migrations and rake tasks for migrating from responses to votes.

When this is deployed the following tasks need to be run:

    $ heroku run rake db:migrate
    $ heroku run rake votes

These need to be done as separate steps otherwise the `FeaturedCountry` model will be missing the `#country_slug=` method and the rake task will fail.

Part of #311 