### PR TITLE
Make sure progress bar doesn't go over 100%

### DIFF
--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -201,7 +201,6 @@
     & > * {
         background-color: $color_green;
         height: 0.5em;
-        min-width: 0.25em;
         float: left;
     }
 
@@ -229,10 +228,6 @@
 }
 
 .progress-bar--gendered {
-    & > * + * {
-        border-left: 1px solid $color_off_white;
-    }
-
     .progress-bar__males {
         background-color: $color_orange;
     }


### PR DESCRIPTION
The extra borders and min-width seemed to be pushing the width of the
progress bar over 100%. Removing these styles appears to fix that
problem.

![screen shot 2016-02-02 at 17 43 28](https://cloud.githubusercontent.com/assets/22996/12758545/a1d6be0c-c9d4-11e5-9461-a79204cd51dc.png)


Fixes #316 