### PR TITLE
Make travis use ruby 2.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.2
+  - 2.2.4
 services:
   - memcached
 before_script:


### PR DESCRIPTION
cb36abce5a52918b74cb1401b02d18a34a8d87e5 bumped the version requirement for ruby, but didn't update for travis.

(And because @chrismytton naughtily did this straight to master, there wasn't a PR to notice the travis failure for)