### PR TITLE
Hide play country button

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,4 +59,8 @@ class User < Sequel::Model
       votes_dataset.select(1).where(person_uuid: :country_uuids__uuid).exists
     ).group_and_count(:country_slug)
   end
+
+  def has_completed_country?(country_slug)
+    remaining_counts.where(country_slug: country_slug).empty?
+  end
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -49,6 +49,7 @@ module Helpers
   end
 
   def country_complete?
-    CountryUUID.where(country_slug: params[:country], gender: nil).empty?
+    return true if CountryUUID.where(country_slug: params[:country], gender: nil).empty?
+    current_user && current_user.has_completed_country?(params[:country])
   end
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -47,4 +47,8 @@ module Helpers
   def previous_legislative_period(legislative_period)
     previous_legislative_periods(legislative_period).first
   end
+
+  def country_complete?
+    CountryUUID.where(country_slug: params[:country], gender: nil).empty?
+  end
 end

--- a/views/report.erb
+++ b/views/report.erb
@@ -16,7 +16,9 @@
         <h1 class="page-title"><%= @country[:country] %></h1>
 
         <p class="report-actions">
-            <a href="<%= url("/countries/#{params[:country]}") %>" class="button button--small">Play this country!</a>
+            <% unless country_complete? %>
+                <a href="<%= url("/countries/#{params[:country]}") %>" class="button button--small">Play this country!</a>
+            <% end %>
             <a href="http://everypolitician.org/<%= params[:country].downcase %>/download.html" class="button button--small">Download data</a>
         </p>
 


### PR DESCRIPTION
When a country already has gender data or a player has already played a country then we need to hide the "Play country" button on the report page as it's not relevant.

![screen shot 2016-07-01 at 10 54 49](https://cloud.githubusercontent.com/assets/22996/16516796/56580eb0-3f7a-11e6-980b-ffcbbaa41342.png)
