### PR TITLE
Refactor report logic

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,6 +28,7 @@ require 'app/models'
 require 'app/jobs'
 require 'csv_export'
 require 'country_proxy'
+require 'reports'
 
 helpers Helpers
 
@@ -168,147 +169,6 @@ get '/countries/:country/legislatures/:legislature' do
   erb :term
 end
 
-# Require including class to define a `stats` method which returns a hash with
-# :female, :male and :total keys.
-module GenderStats
-  def female
-    @female ||= stats[:female].to_f
-  end
-
-  def male
-    @male ||= stats[:male].to_f
-  end
-
-  def total
-    @total ||= stats[:total].to_f
-  end
-
-  def female_percentage
-    @female_percentage ||= female / total * 100
-  end
-
-  def male_percentage
-    @male_percentage ||= male / total * 100
-  end
-end
-
-class LegislatureReport
-  extend Forwardable
-  include GenderStats
-
-  # Delegate 'name' and 'slug' method calls to the 'legislature' object.
-  def_delegators :legislature, :name, :slug
-
-  attr_reader :legislature
-  attr_reader :raw_stats
-
-  def initialize(legislature, raw_stats)
-    @legislature = legislature
-    @raw_stats = raw_stats
-  end
-
-  def stats
-    @stats ||= raw_stats[:totals][:overall]
-  end
-
-  def groups
-    @groups ||= raw_stats[:totals][:parties].map { |slug, group_stats| GroupReport.new(slug, group_stats, raw_stats, legislative_periods) }
-  end
-
-  def legislative_periods
-    @legislative_periods ||= legislature.legislative_periods.map { |lp| LegislativePeriodReport.new(lp, raw_stats) }
-  end
-end
-
-class GroupReport
-  include GenderStats
-
-  attr_reader :slug
-  attr_reader :stats
-  attr_reader :raw_stats
-
-  def initialize(slug, stats, raw_stats, legislative_periods)
-    @slug = slug
-    @stats = stats
-    @raw_stats = raw_stats
-    @legislative_periods = legislative_periods
-  end
-
-  def name
-    stats[:name]
-  end
-
-  def id_slug
-    @id_slug ||= slug.to_s.sub('/', '-')
-  end
-
-  def legislative_periods
-    @legislative_periods.map do |term|
-      term_stats = raw_stats[:terms]["term/#{term.slug}".to_sym]
-      group_stats = term_stats[:parties][slug]
-      GroupLegilativePeriodReport.new(term, group_stats) if group_stats
-    end.compact
-  end
-end
-
-class GroupLegilativePeriodReport
-  include GenderStats
-
-  attr_reader :term
-  attr_reader :stats
-
-  def initialize(term, stats)
-    @term = term
-    @stats = stats
-  end
-
-  def name
-    term.name
-  end
-end
-
-class LegislativePeriodReport
-  extend Forwardable
-  include GenderStats
-
-  # Delegate 'name' and 'slug' method calls to the 'legislative_period' object.
-  def_delegators :legislative_period, :name, :slug
-
-  attr_reader :legislative_period
-  attr_reader :raw_stats
-
-  def initialize(legislative_period, raw_stats)
-    @legislative_period = legislative_period
-    @raw_stats = raw_stats
-  end
-
-  def legislative_period_stats
-    @legislative_period_stats ||= raw_stats[:terms]["term/#{legislative_period.slug}".to_sym]
-  end
-
-  def stats
-    @stats ||= legislative_period_stats[:overall]
-  end
-
-  def groups
-    @groups = legislative_period_stats[:parties].map { |_, group_stats| LegislativePeriodGroupReport.new(group_stats) }
-  end
-end
-
-class LegislativePeriodGroupReport
-  include GenderStats
-
-  attr_reader :stats
-
-  def initialize(stats)
-    @stats = stats
-  end
-
-  def name
-    stats[:name]
-  end
-end
-
 get '/reports/:country' do
   redirect to('/login') unless current_user
   @country = Everypolitician.country(slug: params[:country])
@@ -316,7 +176,7 @@ get '/reports/:country' do
   stats = Hash[stats_raw.map { |c| [c[:slug], c] }]
   @country_stats = stats[params[:country]]
   @legislature_stats = Hash[@country_stats[:legislatures].map {|l| [l[:slug], l]}]
-  @legislatures = @country.legislatures.map { |l| LegislatureReport.new(l, @legislature_stats[l.slug]) }
+  @legislatures = @country.legislatures.map { |l| Reports::LegislatureReport.new(l, @legislature_stats[l.slug]) }
   erb :report, :layout => :layout_page
 end
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -52,4 +52,8 @@ module Helpers
     return true if CountryUUID.where(country_slug: params[:country], gender: nil).empty?
     current_user && current_user.has_completed_country?(params[:country])
   end
+
+  def pluralize(count, singular)
+    "#{count} #{singular.pluralize(count)}"
+  end
 end

--- a/lib/reports.rb
+++ b/lib/reports.rb
@@ -1,0 +1,142 @@
+module Reports
+  # Require including class to define a `stats` method which returns a hash with
+  # :female, :male and :total keys.
+  module GenderStats
+    def female
+      @female ||= stats[:female].to_f
+    end
+
+    def male
+      @male ||= stats[:male].to_f
+    end
+
+    def total
+      @total ||= stats[:total].to_f
+    end
+
+    def female_percentage
+      @female_percentage ||= female / total * 100
+    end
+
+    def male_percentage
+      @male_percentage ||= male / total * 100
+    end
+  end
+
+  class LegislatureReport
+    extend Forwardable
+    include GenderStats
+
+    # Delegate 'name' and 'slug' method calls to the 'legislature' object.
+    def_delegators :legislature, :name, :slug
+
+    attr_reader :legislature
+    attr_reader :raw_stats
+
+    def initialize(legislature, raw_stats)
+      @legislature = legislature
+      @raw_stats = raw_stats
+    end
+
+    def stats
+      @stats ||= raw_stats[:totals][:overall]
+    end
+
+    def groups
+      @groups ||= raw_stats[:totals][:parties].map { |slug, group_stats| GroupReport.new(slug, group_stats, raw_stats, legislative_periods) }
+    end
+
+    def legislative_periods
+      @legislative_periods ||= legislature.legislative_periods.map { |lp| LegislativePeriodReport.new(lp, raw_stats) }
+    end
+  end
+
+  class GroupReport
+    include GenderStats
+
+    attr_reader :slug
+    attr_reader :stats
+    attr_reader :raw_stats
+
+    def initialize(slug, stats, raw_stats, legislative_periods)
+      @slug = slug
+      @stats = stats
+      @raw_stats = raw_stats
+      @legislative_periods = legislative_periods
+    end
+
+    def name
+      stats[:name]
+    end
+
+    def id_slug
+      @id_slug ||= slug.to_s.sub('/', '-')
+    end
+
+    def legislative_periods
+      @legislative_periods.map do |term|
+        term_stats = raw_stats[:terms]["term/#{term.slug}".to_sym]
+        group_stats = term_stats[:parties][slug]
+        GroupLegilativePeriodReport.new(term, group_stats) if group_stats
+      end.compact
+    end
+  end
+
+  class GroupLegilativePeriodReport
+    include GenderStats
+
+    attr_reader :term
+    attr_reader :stats
+
+    def initialize(term, stats)
+      @term = term
+      @stats = stats
+    end
+
+    def name
+      term.name
+    end
+  end
+
+  class LegislativePeriodReport
+    extend Forwardable
+    include GenderStats
+
+    # Delegate 'name' and 'slug' method calls to the 'legislative_period' object.
+    def_delegators :legislative_period, :name, :slug
+
+    attr_reader :legislative_period
+    attr_reader :raw_stats
+
+    def initialize(legislative_period, raw_stats)
+      @legislative_period = legislative_period
+      @raw_stats = raw_stats
+    end
+
+    def legislative_period_stats
+      @legislative_period_stats ||= raw_stats[:terms]["term/#{legislative_period.slug}".to_sym]
+    end
+
+    def stats
+      @stats ||= legislative_period_stats[:overall]
+    end
+
+    def groups
+      @groups = legislative_period_stats[:parties].map { |_, group_stats| LegislativePeriodGroupReport.new(group_stats) }
+    end
+  end
+
+  class LegislativePeriodGroupReport
+    include GenderStats
+
+    attr_reader :stats
+
+    def initialize(stats)
+      @stats = stats
+    end
+
+    def name
+      stats[:name]
+    end
+  end
+end

--- a/views/report.erb
+++ b/views/report.erb
@@ -92,35 +92,28 @@
 
             <div class="col-sm-6">
                 <h3>Gender balance by group:</h3>
-                <% stats = @legislature_stats[legislature.slug][:totals] %>
                 <div class="report-list report-list--by-group">
-                    <% stats[:parties].each do |slug, data|
-                        id_slug = slug.to_s.sub('/', '-') %>
+                    <% legislature.groups.each do |group| %>
                     <%= erb :report_partial, locals: {
                         report: {
-                            id: id_slug,
-                            title: data[:name],
-                            total: data[:total].to_f,
-                            total_male: data[:male].to_f,
-                            total_female: data[:female].to_f,
+                            id: group.id_slug,
+                            title: group.name,
+                            total: group.total,
+                            total_male: group.male,
+                            total_female: group.female,
                             action: 'display-by-term'
                         }
                     } %>
-                    <div class="report-list report-list--hidden" id="terms-<%= id_slug %>">
-                    <% legislature.legislative_periods.each do |term|
-                        term_slug = 'term/' + term.slug
-                        term_stats = @legislature_stats[legislature.slug][:terms][term_slug.to_sym]
-                        group = term_stats[:parties][slug]
-                        if group %>
+                    <div class="report-list report-list--hidden" id="terms-<%= group.id_slug %>">
+                    <% group.legislative_periods.each do |term| %>
                         <%= erb :report_partial, locals: {
                             report: {
                                 title: term.name,
-                                total: group[:total].to_f,
-                                total_male: group[:male].to_f,
-                                total_female: group[:female].to_f,
+                                total: term.total,
+                                total_male: term.male,
+                                total_female: term.female,
                             }
                         } %>
-                    <% end %>
                     <% end %>
                     </div>
                     <% end %>

--- a/views/report.erb
+++ b/views/report.erb
@@ -13,15 +13,15 @@
         </div>
         <% end %>
 
-        <h1 class="page-title"><%= @country[:country] %></h1>
+        <h1 class="page-title"><%= @country.name %></h1>
 
         <p>Here's the gender breakdown for this country's politicians.</p>
 
         <p class="report-actions">
             <% unless country_complete? %>
-                <a href="<%= url("/countries/#{params[:country]}") %>" class="button button--small">Play this country!</a>
+                <a href="<%= url("/countries/#{@country.slug}") %>" class="button button--small">Play this country!</a>
             <% end %>
-            <a href="http://everypolitician.org/<%= params[:country].downcase %>/download.html" class="button button--small">Download data</a>
+            <a href="http://everypolitician.org/<%= @country.slug.downcase %>/download.html" class="button button--small">Download data</a>
         </p>
 
         <div class="report-legislatures">

--- a/views/report.erb
+++ b/views/report.erb
@@ -59,30 +59,29 @@
         <h2 class="page-title"><%= legislature.name %></h2>
 
         <div class="row">
+
             <div class="col-sm-6">
                 <h3>Gender balance by term:</h3>
                 <div class="report-list report-list--by-term">
                     <% legislature.legislative_periods.each do |term| %>
-                        <% term_slug = 'term/' + term.slug
-                        term_stats = @legislature_stats[legislature.slug][:terms][term_slug.to_sym] %>
                         <%= erb :report_partial, locals: {
                             report: {
                                 id: term.slug,
                                 title: term.name,
-                                total: term_stats[:overall][:total].to_f,
-                                total_male: term_stats[:overall][:male].to_f,
-                                total_female: term_stats[:overall][:female].to_f,
+                                total: term.total,
+                                total_male: term.male,
+                                total_female: term.female,
                                 action: 'display-by-group'
                             }
                         } %>
                         <div class="report-list report-list--hidden" id="parties-<%= term.slug %>">
-                        <% term_stats[:parties].each do |slug, group| %>
+                        <% term.groups.each do |group| %>
                         <%= erb :report_partial, locals: {
                             report: {
-                                title: group[:name],
-                                total: group[:total].to_f,
-                                total_male: group[:male].to_f,
-                                total_female: group[:female].to_f,
+                                title: group.name,
+                                total: group.total,
+                                total_male: group.male,
+                                total_female: group.female,
                             }
                         } %>
                         <% end %>
@@ -90,6 +89,7 @@
                     <% end %>
                 </div>
             </div>
+
             <div class="col-sm-6">
                 <h3>Gender balance by group:</h3>
                 <% stats = @legislature_stats[legislature.slug][:totals] %>
@@ -114,7 +114,7 @@
                         if group %>
                         <%= erb :report_partial, locals: {
                             report: {
-                                title: term[:name],
+                                title: term.name,
                                 total: group[:total].to_f,
                                 total_male: group[:male].to_f,
                                 total_female: group[:female].to_f,
@@ -126,6 +126,7 @@
                     <% end %>
                 </div>
             </div>
+
         </div>
     </div>
 </div>

--- a/views/report.erb
+++ b/views/report.erb
@@ -25,28 +25,20 @@
         </p>
 
         <div class="report-legislatures">
-            <% @country.legislatures.each_slice(2) do |legislatures| %>
+            <% @legislatures.each_slice(2) do |legislatures| %>
             <div class="row">
                 <% legislatures.each do |legislature| %>
-                <%
-                    stats = @legislature_stats[legislature.slug][:totals]
-                    total = stats[:overall][:total].to_f
-                    male = stats[:overall][:male].to_f
-                    female = stats[:overall][:female].to_f
-                    total = male + female
-                %>
                 <div class="col-sm-6">
-
                     <a class="list__item country" href="#<%= legislature.slug %>" data-scroll-to-id>
                         <h3 class="country__name"><%= legislature.name %></h3>
                         <div class="country__progress">
                             <p class="country__progress__intro">Known gender balance for <%= legislature.name %>:</p>
                             <div class="progress-bar progress-bar--gendered progress-bar--labelled">
-                                <div class="progress-bar__males" style="width: <%= male / total * 100 %>%">
-                                    <span class="progress-bar__label"><%= male.to_i %> <%= male.to_i == 1 ? 'man' : 'men' %></span>
+                                <div class="progress-bar__males" style="width: <%= legislature.male_percentage %>%">
+                                    <span class="progress-bar__label"><%= pluralize(legislature.male.to_i, 'man') %></span>
                                 </div>
-                                <div class="progress-bar__females" style="width: <%= female / total * 100 %>%">
-                                    <span class="progress-bar__label"><%= female.to_i %> <%= female.to_i == 1 ? 'woman' : 'women' %></span>
+                                <div class="progress-bar__females" style="width: <%= legislature.female_percentage %>%">
+                                    <span class="progress-bar__label"><%= pluralize(legislature.female.to_i, 'woman') %></span>
                                 </div>
                             </div>
                         </div>
@@ -60,7 +52,7 @@
     </div>
 </div>
 
-<% @country.legislatures.each do |legislature| %>
+<% @legislatures.each do |legislature| %>
 <div class="page-section page-section--white" id="<%= legislature.slug %>">
     <div class="container">
 


### PR DESCRIPTION
First step of removing report logic from the template so that it's easier to understand/reason about/work with.

Possible next steps:

- Add a class that munges the stats data into a shape that's easier to work with in the template (or possible do that in [gender-balance-country-stats](https://github.com/everypolitician/gender-balance-country-stats).
- Add some tests for the report logic
- Reduce the duplication in the reporting classes