### PR TITLE
Rename conflicting %col-float placeholder

### DIFF
--- a/views/sass/_grid.scss
+++ b/views/sass/_grid.scss
@@ -29,13 +29,13 @@ $grid-breakpoint-sm: 768px !default;
 }
 
 @media(min-width: $grid-breakpoint-sm) {
-    %col-float {
+    %col-float-left {
         float: left;
     }
 
     @for $i from 1 through 12 {
         .col-sm-#{$i} {
-            @extend %col-float;
+            @extend %col-float-left;
             width: 100% / 12 * $i;
         }
     }


### PR DESCRIPTION
The _mysociety-footer.scss and _grid.scss were both defining the same
placeholder "%col-float". This change renames the grid placeholder name to avoid
sass compilation errors.

Prevents errors like:

```
2016-07-01 14:23:24 - Sass::SyntaxError - You may not @extend an outer selector from within @media.
You may only @extend selectors within the same directive.
From "@extend %col-float" on line 38 of /vagrant/views/sass/_grid.scss.
:
        /vagrant/views/sass/_mysociety-footer.scss:75
```