### PR TITLE
Change copy when country has no gender information

### DIFF
--- a/views/country_partial.erb
+++ b/views/country_partial.erb
@@ -34,7 +34,7 @@
                 </div>
             </div>
         <% else %>
-            <p class="country__progress__intro">We don’t know any gender data for <%= country.name %> yet!</p>
+            <p class="country__progress__intro">The gender breakdown for <%= country.name %> will display here, once enough other people have played.</p>
             <div class="progress-bar progress-bar--gendered"></div>
         <% end %>
     </div>


### PR DESCRIPTION
This is displayed when we have no conclusive gender information for a country, whether a player has played it already or not. I've taken the wording suggested in https://github.com/everypolitician/gender-balance/issues/322#issuecomment-184699640 but dropped the "Thanks for playing." bit as it doesn't make sense if the user hasn't played it yet and it was a bit long to fit on the card.

Fixes #322 

![screen shot 2016-07-01 at 16 48 13](https://cloud.githubusercontent.com/assets/22996/16525247/bb41e3ba-3fab-11e6-8995-897121621dca.png)
