### PR TITLE
Make sure bars are rounded when 0 men or women

### DIFF
--- a/views/report.erb
+++ b/views/report.erb
@@ -34,12 +34,16 @@
                         <div class="country__progress">
                             <p class="country__progress__intro">Known gender balance for <%= legislature.name %>:</p>
                             <div class="progress-bar progress-bar--gendered progress-bar--labelled">
+                                <% unless legislature.male.zero? %>
                                 <div class="progress-bar__males" style="width: <%= legislature.male_percentage %>%">
                                     <span class="progress-bar__label"><%= pluralize(legislature.male.to_i, 'man') %></span>
                                 </div>
+                                <% end %>
+                                <% unless legislature.female.zero? %>
                                 <div class="progress-bar__females" style="width: <%= legislature.female_percentage %>%">
                                     <span class="progress-bar__label"><%= pluralize(legislature.female.to_i, 'woman') %></span>
                                 </div>
+                                <% end %>
                             </div>
                         </div>
                     </a>

--- a/views/report_partial.erb
+++ b/views/report_partial.erb
@@ -9,16 +9,22 @@
   <% end %>
 
     <div class="progress-bar progress-bar--gendered progress-bar--labelled">
+      <% unless report[:total_male].zero? %>
         <div class="progress-bar__males" style="width: <%= report[:total_male] / report[:total] * 100 %>%">
             <span class="progress-bar__label"><%= report[:total_male].to_i %> <%= report[:total_male].to_i == 1 ? 'man' : 'men' %></span>
         </div>
+      <% end %>
+
       <% if (report[:total_male] + report[:total_female] != report[:total]) %>
         <div class="progress-bar__empty" style="width: <%= (report[:total] - report[:total_male] - report[:total_female]) / report[:total] * 100 %>%">
         </div>
       <% end %>
+
+      <% unless report[:total_female].zero? %>
         <div class="progress-bar__females" style="width: <%= report[:total_female] / report[:total] * 100 %>%">
             <span class="progress-bar__label"><%= report[:total_female].to_i %> <%= report[:total_female].to_i == 1 ? 'woman' : 'women' %></span>
         </div>
+      <% end %>
     </div>
 
 </div>


### PR DESCRIPTION
When the gender count is 0 don't show the progress bars since it breaks
the display and makes the rounded bars appear squared off.

![screen shot 2016-07-01 at 17 57 02](https://cloud.githubusercontent.com/assets/22996/16527114/3e7c2322-3fb5-11e6-9b35-bb6ed541e7ac.png)
