### PR TITLE
Add indexes to country_uuids.uuid and votes.person_uuid

### DIFF
--- a/db/migrations/018_add_uuid_indexes.rb
+++ b/db/migrations/018_add_uuid_indexes.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  change do
+    alter_table(:country_uuids) do
+      add_index :uuid
+    end
+
+    alter_table(:votes) do
+      add_index :person_uuid
+    end
+  end
+end


### PR DESCRIPTION
When generating the CSV export we do a join between these two tables on
these two columns. For legislatures with lots of people, like Greece,
this was starting to get very slow on Heroku. This change should help to
keep the CSV export snappy and prevent timeouts.