### PR TITLE
Fix congratulations page to call methods on ep-ruby objects

### DIFF
--- a/views/congratulations.erb
+++ b/views/congratulations.erb
@@ -7,17 +7,17 @@
 <div class="person-cards">
     <div class="level-complete">
         <h2><%= motivational_quote %></h2>
-        <% if @country[:legislatures].size == 1 %>
-            <p>You have completed <b><%= @country[:name] %></b>!</p>
+        <% if @country.legislatures.size == 1 %>
+            <p>You have completed <b><%= @country.name %></b>!</p>
             <p>
                 <a class="button button--secondary" href="<%= url "/countries" %>">
                     Choose another country
                 </a>
             </p>
         <% else %>
-            <p>You have completed <b><%= @country[:name] %> <%= @legislature[:name] %></b>!</p>
+            <p>You have completed <b><%= @country.name %> <%= @legislature.name %></b>!</p>
             <p>
-                <a class="button button--secondary" href="<%= url "/countries/#{@country[:slug]}" %>">
+                <a class="button button--secondary" href="<%= url "/countries/#{@country.slug}" %>">
                     Choose another legislature
                 </a>
             </p>


### PR DESCRIPTION
This view wasn't updated when we switched to everypolitician-ruby, so it
was causing an error because the version of ep-ruby this app is using
doesn't have the Legislature#[] method.

Fixes https://github.com/everypolitician/gender-balance/issues/357