### PR TITLE
Remove people that disappear from EveryPolitician

### DIFF
--- a/app/jobs/update_cache_job.rb
+++ b/app/jobs/update_cache_job.rb
@@ -13,6 +13,11 @@ class UpdateCacheJob
           )
           country_uuid.update(gender: person[:gender])
         end
+        ep_ids = legislature.popolo.persons.map(&:id)
+        gb_ids = CountryUUID.where(country_slug: country.slug, legislature_slug: legislature.slug).map(&:uuid)
+        missing_uuids = gb_ids - ep_ids
+        Vote.where(person_uuid: missing_uuids).delete
+        CountryUUID.where(uuid: missing_uuids).delete
       end
     end
   end


### PR DESCRIPTION
When a person gets merged on Wikidata they effectively disappear from EveryPolitician, but we still have them cached in the `country_uuids` table. This change checks for any people that have been removed and deletes the associated `votes` and `country_uuids` tables.

Fixes https://github.com/everypolitician/gender-balance/issues/336